### PR TITLE
feat: add support for octal, base64, and hex string literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,12 @@ name = "ast"
 version = "0.1.0"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +276,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "indexmap"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,7 +346,9 @@ name = "lexer"
 version = "0.1.0"
 dependencies = [
  "ast",
+ "base64",
  "diag",
+ "hex",
  "unicode-segmentation",
  "utils",
 ]

--- a/crates/ast/src/ast.rs
+++ b/crates/ast/src/ast.rs
@@ -195,6 +195,9 @@ pub enum LiteralKind {
     Bool(bool),
     String(String, Option<StringPrefix>),
     Char(char),
+    OctalString(i64),
+    Base64String(String),
+    HexString(String),
     Null,
 }
 
@@ -202,6 +205,8 @@ pub enum LiteralKind {
 pub enum StringPrefix {
     C, // C-style string which is const char*
     B, // Bytes string
+    B64,
+    X, // Hex string (e.g. x"48656C6C6F")
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/ast/src/format.rs
+++ b/crates/ast/src/format.rs
@@ -19,16 +19,21 @@ impl fmt::Display for Literal {
             LiteralKind::Integer(integer) => write!(f, "{}", integer),
             LiteralKind::Bool(bool) => write!(f, "{}", bool),
             LiteralKind::String(string_type, prefix) => {
-                if let Some(prefix) = prefix {
-                    match prefix {
-                        StringPrefix::C => write!(f, "c"),
-                        StringPrefix::B => write!(f, "b"),
-                    };
-                } 
-                write!(f, "\"{}\"", string_type)
-            }
+                        if let Some(prefix) = prefix {
+                            match prefix {
+                                StringPrefix::C => write!(f, "c")?,
+                                StringPrefix::B => write!(f, "b")?,
+                                StringPrefix::B64 => write!(f, "b64")?,
+                                StringPrefix::X => write!(f, "x")?,
+                            };
+                        }
+                        write!(f, "\"{}\"", string_type)
+                    }
             LiteralKind::Float(float) => write!(f, "{}", float),
             LiteralKind::Char(ch) => write!(f, "{}", ch),
+            LiteralKind::Base64String(bs) => write!(f, "{}", bs),
+            LiteralKind::HexString(hs) => write!(f, "{}", hs),
+            LiteralKind::OctalString(os) => write!(f, "{}", os),
             LiteralKind::Null => write!(f, "null"),
         }
     }

--- a/crates/lexer/Cargo.toml
+++ b/crates/lexer/Cargo.toml
@@ -8,6 +8,9 @@ ast = { path = "../ast", version = "*" }
 utils = { path = "../utils", version = "*" }
 diag = { path = "../diag", version = "*" }
 unicode-segmentation = "1.9.0"
+hex = "*"
+base64 = "*"
+
 
 [lib]
 name = "lexer"

--- a/crates/lexer/src/lib.rs
+++ b/crates/lexer/src/lib.rs
@@ -559,17 +559,22 @@ impl Lexer {
 
     fn read_identifier(&mut self) -> Token {
         let start = self.pos;
+        let mut ident = String::new();
 
-        let mut final_identifier = String::new();
+        // First character must be alphabetic or underscore
+        if self.ch.is_alphabetic() || self.ch == '_' {
+            ident.push(self.ch);
+            self.read_char();
+        }
 
+        // Subsequent characters can be alphanumeric or underscore
         while self.ch.is_alphanumeric() || self.ch == '_' {
-            final_identifier.push(self.ch);
+            ident.push(self.ch);
             self.read_char();
         }
 
         let end = self.pos;
-
-        let token_kind = self.lookup_identifier(final_identifier);
+        let token_kind = self.lookup_identifier(ident);
 
         Token {
             kind: token_kind,

--- a/crates/lexer/src/lib.rs
+++ b/crates/lexer/src/lib.rs
@@ -858,122 +858,6 @@ impl Lexer {
             span: Span { start, end: self.pos },
             loc: Location::new(self.line, self.column),
         }
-
-        // if self.ch == '0' && self.peek_char().to_ascii_lowercase() == 'o' {
-        //     let mut number_str = String::new();
-        //     self.read_char(); // '0'
-        //     self.read_char(); // 'o'
-
-        //     while ('0'..='7').contains(&self.ch) || self.ch == '_' {
-        //         if self.ch != '_' { number_str.push(self.ch); }
-        //         self.read_char();
-        //     }
-
-        //     return match i64::from_str_radix(&number_str, 8) {
-        //         Ok(val) => Token {
-        //             kind: TokenKind::Literal(
-        //                 Literal {
-        //                     kind: LiteralKind::Integer(val),
-        //                     loc: loc.clone(),
-        //                     span: Span::new(start, self.pos)}
-        //                 ),
-        //             span: Span::new(start, self.pos),
-        //             loc,
-        //         },
-        //         Err(_) => { /* error Octal */ exit(1); }
-        //     };
-        // }
-
-    }
-
-    fn read_base64_string(&mut self) -> Token {
-        let start = self.pos;
-
-        // Consume 'b64"' prefix
-        self.read_char(); // 'b'
-        self.read_char(); // '6'
-        self.read_char(); // '4'
-        self.read_char(); // '"'
-
-        let mut content = String::new();
-
-        while self.ch != '"' && !self.is_eof() {
-            content.push(self.ch);
-            self.read_char();
-        }
-
-        if self.is_eof() {
-            CompileTimeError {
-                location: Location {
-                    line: self.line,
-                    column: self.column,
-                },
-                source_content: Box::new(self.input.clone()),
-                etype: LexicalErrorType::UnterminatedStringLiteral,
-                verbose: None,
-                caret: Some(Span::new(start, self.pos)),
-                file_name: Some(self.file_name.clone()),
-            }
-            .print();
-            exit(1);
-        }
-
-        self.read_char(); // consume closing quote
-
-        Token {
-            kind: TokenKind::Literal(Literal {
-                kind: LiteralKind::Base64String(content),
-                loc: Location::new(self.line, self.column),
-                span: Span::new(start, self.pos),
-            }),
-            span: Span::new(start, self.pos),
-            loc: Location::new(self.line, self.column),
-        }
-    }
-
-    fn read_hex_string(&mut self) -> Token {
-        let start = self.pos;
-
-        // Consume 'x"' prefix
-        self.read_char(); // 'x'
-        self.read_char(); // '"'
-
-        let mut content = String::new();
-
-        while self.ch != '"' && !self.is_eof() {
-            if !self.ch.is_whitespace() { // Skip whitespace
-                content.push(self.ch);
-            }
-            self.read_char();
-        }
-
-        if self.is_eof() {
-            CompileTimeError {
-                location: Location {
-                    line: self.line,
-                    column: self.column,
-                },
-                source_content: Box::new(self.input.clone()),
-                etype: LexicalErrorType::UnterminatedStringLiteral,
-                verbose: None,
-                caret: Some(Span::new(start, self.pos)),
-                file_name: Some(self.file_name.clone()),
-            }
-            .print();
-            exit(1);
-        }
-
-        self.read_char(); // consume closing quote
-
-        Token {
-            kind: TokenKind::Literal(Literal {
-                kind: LiteralKind::HexString(content),
-                loc: Location::new(self.line, self.column),
-                span: Span::new(start, self.pos),
-            }),
-            span: Span::new(start, self.pos),
-            loc: Location::new(self.line, self.column),
-        }
     }
 
     fn is_numeric(&self, ch: char) -> bool {
@@ -1003,14 +887,6 @@ impl Lexer {
             | '\u{2028}' // LINE SEPARATOR
             | '\u{2029}' // PARAGRAPH SEPARATOR
         )
-    }
-
-    fn peek_ahead(&self, n: usize) -> char {
-        let mut chars = self.input[self.next_pos..].chars();
-        for _ in 0..n-1 {
-            chars.next();
-        }
-        chars.next().unwrap_or('\0')
     }
 
     fn skip_whitespace(&mut self) {

--- a/examples/main.cyr
+++ b/examples/main.cyr
@@ -3,6 +3,10 @@ extern fn printf(format: const char*, ...);
 fn main() {
     #barr = b"Hello World\n";
 
+    #a = 0o770;
+    #s = b64"SGVsbG8gV29ybGQh";
+    // #s hello_world_hex = x"4865 6c6c 6f20 776f 726c 6421";
+
     foreach (item in barr) {
         printf("value: %c", item);
     }

--- a/examples/main.cyr
+++ b/examples/main.cyr
@@ -5,7 +5,7 @@ fn main() {
 
     #a = 0o770;
     #s = b64"SGVsbG8gV29ybGQh";
-    // #s hello_world_hex = x"4865 6c6c 6f20 776f 726c 6421";
+    #hello_world_hex = x"4865 6c6c 6f20 776f 726c 6421";
 
     foreach (item in barr) {
         printf("value: %c", item);


### PR DESCRIPTION
This PR implements support for:
- Octal literals with `0o` prefix (e.g. `0o770`)
- Base64-encoded string literals with `b64""` prefix
- Hex-encoded string literals with `x""` prefix
- Proper error handling and validation

## Changes
- Added lexer support for new literal formats
- Implemented decoding logic
- Added comprehensive error handling

Resolves #157