### PR TITLE
Add HashMap, Arena allocator and hashing to stdlib (+ 3 compiler fixes)

### DIFF
--- a/crates/cyrusc_analyzer/src/infer.rs
+++ b/crates/cyrusc_analyzer/src/infer.rs
@@ -130,6 +130,7 @@ impl InferCtx {
                 self.bind(*id, ty.clone());
                 true
             }
+            (SemaType::Plain(p1), SemaType::Plain(p2)) => p1 == p2,
             (SemaType::Named(n1), SemaType::Named(n2)) => {
                 if n1.type_decl_id != n2.type_decl_id {
                     return false;

--- a/crates/cyrusc_internal/src/cir/lower.rs
+++ b/crates/cyrusc_internal/src/cir/lower.rs
@@ -23,6 +23,12 @@ use cyrusc_typed_ast::{
 };
 use fx_hash::FxHashSet;
 
+use std::cell::RefCell;
+
+thread_local! {
+    static LOWERING_NAMED_TYPES: RefCell<Vec<String>> = RefCell::new(Vec::new());
+}
+
 pub fn lower_sema_type(decl_tables: &DeclTablesRegistry, target: &ABITarget, ty: &SemaType) -> CIRType {
     match ty {
         SemaType::Plain(plain_type) => CIRType::Plain(plain_type.clone()),
@@ -69,6 +75,62 @@ pub fn lower_sema_type(decl_tables: &DeclTablesRegistry, target: &ABITarget, ty:
 }
 
 pub fn lower_named_type(decl_tables: &DeclTablesRegistry, target: &ABITarget, named_type: &NamedType) -> CIRType {
+    if !matches!(
+        named_type.type_decl_id,
+        TypeDeclID::Struct(_) | TypeDeclID::Union(_) | TypeDeclID::Enum(_)
+    ) {
+        return lower_named_type_inner(decl_tables, target, named_type);
+    }
+
+    let key = format!("{:?}::{:?}", named_type.type_decl_id, named_type.type_args);
+
+    let is_recursing = LOWERING_NAMED_TYPES.with(|stack| stack.borrow().iter().any(|entry| entry == &key));
+
+    if is_recursing {
+        return recursive_named_type_placeholder(decl_tables, named_type);
+    }
+
+    LOWERING_NAMED_TYPES.with(|stack| {
+        stack.borrow_mut().push(key.clone());
+    });
+
+    let result = lower_named_type_inner(decl_tables, target, named_type);
+
+    LOWERING_NAMED_TYPES.with(|stack| {
+        stack.borrow_mut().pop();
+    });
+
+    result
+}
+
+fn recursive_named_type_placeholder(decl_tables: &DeclTablesRegistry, named_type: &NamedType) -> CIRType {
+    let (name, loc) = match named_type.type_decl_id {
+        TypeDeclID::Struct(struct_decl_id) => {
+            let struct_decl = decl_tables.struct_decl(struct_decl_id);
+            (struct_decl.name.clone(), struct_decl.loc)
+        }
+        TypeDeclID::Union(union_decl_id) => {
+            let union_decl = decl_tables.union_decl(union_decl_id);
+            (union_decl.name.clone(), union_decl.loc)
+        }
+        TypeDeclID::Enum(enum_decl_id) => {
+            let enum_decl = decl_tables.enum_decl(enum_decl_id);
+            (enum_decl.name.clone(), enum_decl.loc)
+        }
+        _ => unreachable!(),
+    };
+
+    CIRType::Struct(CIRStructType {
+        name,
+        fields: Vec::new(),
+        fields_info: Vec::new(),
+        repr_attr: None,
+        align: None,
+        loc,
+    })
+}
+
+fn lower_named_type_inner(decl_tables: &DeclTablesRegistry, target: &ABITarget, named_type: &NamedType) -> CIRType {
     match named_type.type_decl_id {
         TypeDeclID::Struct(struct_decl_id) => {
             let struct_decl = decl_tables.struct_decl(struct_decl_id);

--- a/crates/cyrusc_parser/src/exprs.rs
+++ b/crates/cyrusc_parser/src/exprs.rs
@@ -1564,8 +1564,6 @@ fn is_comparison_operator(token_kind: &TokenKind) -> bool {
             | TokenKind::LessThan
             | TokenKind::GreaterEqual
             | TokenKind::GreaterThan
-            | TokenKind::And
-            | TokenKind::Or
     )
 }
 

--- a/stdlib/collections.cyrus
+++ b/stdlib/collections.cyrus
@@ -306,3 +306,244 @@ pub struct Vector<T> {
 // pub struct LinkedList<T> {
 
 // }
+
+const initial_map_capacity: usize = 16;
+
+const SLOT_EMPTY: uint8 = 0;
+const SLOT_OCCUPIED: uint8 = 1;
+const SLOT_DELETED: uint8 = 2;
+
+pub struct HashMap<K, V> {
+    allocator: Allocator;
+    keys: K*;
+    values: V*;
+    states: uint8*;
+    cap: usize;
+    len: usize;
+    tombstones: usize;
+    hash_fn: fn(K*) uint64;
+    eq_fn: fn(K*, K*) bool;
+
+    pub inline fn new(const allocator: Allocator, hash_fn: fn(K*) uint64, eq_fn: fn(K*, K*) bool) Self {
+        return HashMap.with_capacity(allocator, initial_map_capacity, hash_fn, eq_fn);
+    }
+
+    pub inline fn with_capacity(const allocator: Allocator, const cap: usize, hash_fn: fn(K*) uint64, eq_fn: fn(K*, K*) bool) Self {
+        const real_cap = round_up_pow2(cap);
+
+        const keys: K* = allocator.alloc(real_cap * @sizeof(K));
+        const values: V* = allocator.alloc(real_cap * @sizeof(V));
+        const states: uint8* = allocator.alloc_zeroed(real_cap * @sizeof(uint8));
+
+        if (keys == null || values == null || states == null) {
+            @panic("hashmap allocation failed");
+        }
+
+        return Self {
+            allocator,
+            keys,
+            values,
+            states,
+            cap: real_cap,
+            len: 0,
+            tombstones: 0,
+            hash_fn,
+            eq_fn,
+        };
+    }
+
+    pub inline fn put(&self, key: K, value: V) {
+        if ((self->len + self->tombstones + 1) * 4 >= self->cap * 3) {
+            self->grow();
+        }
+
+        self->insert_no_grow(key, value);
+    }
+
+    fn insert_no_grow(&self, key: K, value: V) {
+        const hf = self->hash_fn;
+        const ef = self->eq_fn;
+
+        const hash = hf(&key);
+
+        var idx = @cast(usize, hash) & (self->cap - 1);
+        var tombstone_idx = self->cap;
+
+        while (true) {
+            const state = self->states[idx];
+
+            if (state == SLOT_EMPTY) {
+                var target = idx;
+
+                if (tombstone_idx != self->cap) {
+                    target = tombstone_idx;
+                    self->tombstones -= 1;
+                }
+
+                self->keys[target] = key;
+                self->values[target] = value;
+                self->states[target] = SLOT_OCCUPIED;
+                self->len += 1;
+
+                return;
+            }
+
+            if (state == SLOT_DELETED) {
+                if (tombstone_idx == self->cap) {
+                    tombstone_idx = idx;
+                }
+            } else {
+                if (ef(self->keys + idx, &key)) {
+                    self->values[idx] = value;
+
+                    return;
+                }
+            }
+
+            idx = (idx + 1) & (self->cap - 1);
+        }
+    }
+
+    pub inline fn get(&const self, key: K) Option<V> {
+        switch (self->find(&key)) {
+            case .Some(idx) => return .Some(self->values[idx]);
+            case .None => return .None;
+        }
+    }
+
+    pub inline fn get_ref(&const self, key: K) Option<V*> {
+        switch (self->find(&key)) {
+            case .Some(idx) => return .Some(self->values + idx);
+            case .None => return .None;
+        }
+    }
+
+    pub inline fn contains(&const self, key: K) bool {
+        return self->find(&key).is_some();
+    }
+
+    pub inline fn remove(&self, key: K) bool {
+        switch (self->find(&key)) {
+            case .Some(idx) => {
+                self->states[idx] = SLOT_DELETED;
+                self->len -= 1;
+                self->tombstones += 1;
+
+                return true;
+            }
+
+            case .None => return false;
+        }
+    }
+
+    pub inline fn len(&const self) usize {
+        return self->len;
+    }
+
+    pub inline fn cap(&const self) usize {
+        return self->cap;
+    }
+
+    pub inline fn is_empty(&const self) bool {
+        return self->len == 0;
+    }
+
+    pub inline fn clear(&self) {
+        @memset(self->states, 0, self->cap * @sizeof(uint8));
+
+        self->len = 0;
+        self->tombstones = 0;
+    }
+
+    pub inline fn free(&self) {
+        if (self->keys != null) {
+            self->allocator.free(@cast(void*, self->keys));
+            self->allocator.free(@cast(void*, self->values));
+            self->allocator.free(@cast(void*, self->states));
+
+            self->keys = null;
+            self->values = null;
+            self->states = null;
+            self->cap = 0;
+            self->len = 0;
+            self->tombstones = 0;
+        }
+    }
+
+    fn find(&const self, key: K*) Option<usize> {
+        const hf = self->hash_fn;
+        const ef = self->eq_fn;
+
+        const hash = hf(key);
+
+        var idx = @cast(usize, hash) & (self->cap - 1);
+        var probes: usize = 0;
+
+        while (probes < self->cap) {
+            const state = self->states[idx];
+
+            if (state == SLOT_EMPTY) {
+                return .None;
+            }
+
+            if (state == SLOT_OCCUPIED) {
+                if (ef(self->keys + idx, key)) {
+                    return .Some(idx);
+                }
+            }
+
+            idx = (idx + 1) & (self->cap - 1);
+            probes += 1;
+        }
+
+        return .None;
+    }
+
+    fn grow(&self) {
+        const old_cap = self->cap;
+        const old_keys = self->keys;
+        const old_values = self->values;
+        const old_states = self->states;
+
+        var new_cap = old_cap * 2;
+
+        if (new_cap == 0) {
+            new_cap = initial_map_capacity;
+        }
+
+        const new_keys: K* = self->allocator.alloc(new_cap * @sizeof(K));
+        const new_values: V* = self->allocator.alloc(new_cap * @sizeof(V));
+        const new_states: uint8* = self->allocator.alloc_zeroed(new_cap * @sizeof(uint8));
+
+        if (new_keys == null || new_values == null || new_states == null) {
+            @panic("hashmap reallocation failed");
+        }
+
+        self->keys = new_keys;
+        self->values = new_values;
+        self->states = new_states;
+        self->cap = new_cap;
+        self->len = 0;
+        self->tombstones = 0;
+
+        for (var i: usize = 0; i < old_cap; i++) {
+            if (old_states[i] == SLOT_OCCUPIED) {
+                self->insert_no_grow(old_keys[i], old_values[i]);
+            }
+        }
+
+        self->allocator.free(@cast(void*, old_keys));
+        self->allocator.free(@cast(void*, old_values));
+        self->allocator.free(@cast(void*, old_states));
+    }
+}
+
+inline fn round_up_pow2(v: usize) usize {
+    var n: usize = initial_map_capacity;
+
+    while (n < v) {
+        n *= 2;
+    }
+
+    return n;
+}

--- a/stdlib/hash.cyrus
+++ b/stdlib/hash.cyrus
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Cyrus Language
+
+import std::libc{strlen};
+
+const FNV_OFFSET_BASIS_32: uint32 = 0x811c9dc5;
+const FNV_PRIME_32: uint32 = 0x01000193;
+
+const FNV_OFFSET_BASIS_64: uint64 = 0xcbf29ce484222325;
+const FNV_PRIME_64: uint64 = 0x00000100000001b3;
+
+const MURMUR_C1: uint32 = 0xcc9e2d51;
+const MURMUR_C2: uint32 = 0x1b873593;
+const MURMUR_R1: uint32 = 15;
+const MURMUR_R2: uint32 = 13;
+const MURMUR_M: uint32 = 5;
+const MURMUR_N: uint32 = 0xe6546b64;
+const MURMUR_FMIX1: uint32 = 0x85ebca6b;
+const MURMUR_FMIX2: uint32 = 0xc2b2ae35;
+
+pub inline fn rotl32(x: uint32, r: uint32) uint32 {
+    return (x << r) | (x >> (32 - r));
+}
+
+pub fn fnv1a_32(const data: const void*, const len: usize) uint32 {
+    const bytes = @cast(const uint8*, data);
+
+    var hash: uint32 = FNV_OFFSET_BASIS_32;
+
+    for (var i: usize = 0; i < len; i++) {
+        hash = hash ^ @cast(uint32, bytes[i]);
+        hash = hash * FNV_PRIME_32;
+    }
+
+    return hash;
+}
+
+pub fn fnv1a_64(const data: const void*, const len: usize) uint64 {
+    const bytes = @cast(const uint8*, data);
+
+    var hash: uint64 = FNV_OFFSET_BASIS_64;
+
+    for (var i: usize = 0; i < len; i++) {
+        hash = hash ^ @cast(uint64, bytes[i]);
+        hash = hash * FNV_PRIME_64;
+    }
+
+    return hash;
+}
+
+pub fn murmur3_32(const data: const void*, const len: usize, const seed: uint32) uint32 {
+    const bytes = @cast(const uint8*, data);
+
+    var hash: uint32 = seed;
+
+    const nblocks = len / 4;
+
+    for (var i: usize = 0; i < nblocks; i++) {
+        const base = i * 4;
+
+        var k: uint32 = @cast(uint32, bytes[base])
+            | (@cast(uint32, bytes[base + 1]) << 8)
+            | (@cast(uint32, bytes[base + 2]) << 16)
+            | (@cast(uint32, bytes[base + 3]) << 24);
+
+        k = k * MURMUR_C1;
+        k = rotl32(k, MURMUR_R1);
+        k = k * MURMUR_C2;
+
+        hash = hash ^ k;
+        hash = rotl32(hash, MURMUR_R2);
+        hash = (hash * MURMUR_M) + MURMUR_N;
+    }
+
+    const tail = nblocks * 4;
+    const remainder = len & 3;
+
+    var k1: uint32 = 0;
+
+    if (remainder >= 3) {
+        k1 = k1 ^ (@cast(uint32, bytes[tail + 2]) << 16);
+    }
+
+    if (remainder >= 2) {
+        k1 = k1 ^ (@cast(uint32, bytes[tail + 1]) << 8);
+    }
+
+    if (remainder >= 1) {
+        k1 = k1 ^ @cast(uint32, bytes[tail]);
+        k1 = k1 * MURMUR_C1;
+        k1 = rotl32(k1, MURMUR_R1);
+        k1 = k1 * MURMUR_C2;
+        hash = hash ^ k1;
+    }
+
+    hash = hash ^ @cast(uint32, len);
+    hash = hash ^ (hash >> 16);
+    hash = hash * MURMUR_FMIX1;
+    hash = hash ^ (hash >> 13);
+    hash = hash * MURMUR_FMIX2;
+    hash = hash ^ (hash >> 16);
+
+    return hash;
+}
+
+pub inline fn hash_bytes(const data: const void*, const len: usize) uint64 {
+    return fnv1a_64(data, len);
+}
+
+pub inline fn hash_str(const str: const char*) uint64 {
+    return fnv1a_64(@cast(const void*, str), strlen(str));
+}

--- a/stdlib/mem/index.cyrus
+++ b/stdlib/mem/index.cyrus
@@ -48,8 +48,138 @@ pub struct LibcAllocator : Allocator {
 	}
 }
 
-pub struct ArenaAllocator {
+const ARENA_DEFAULT_BLOCK_SIZE: usize = 4096;
+const ARENA_DEFAULT_ALIGNMENT: usize = 16;
 
+pub struct ArenaBlock {
+	pub data: void*;
+	pub cap: usize;
+	pub used: usize;
+	pub next: ArenaBlock*;
+}
+
+pub struct ArenaAllocator : Allocator {
+	backing: Allocator;
+	current: ArenaBlock*;
+	block_size: usize;
+
+	pub fn new(const backing: Allocator) Self {
+		return Self {
+			backing,
+			current: null,
+			block_size: ARENA_DEFAULT_BLOCK_SIZE,
+		};
+	}
+
+	pub fn with_block_size(const backing: Allocator, const block_size: usize) Self {
+		@assert(block_size != 0, "block size cannot be zero");
+
+		return Self {
+			backing,
+			current: null,
+			block_size,
+		};
+	}
+
+	fn new_block(&self, const min_size: usize) ArenaBlock* {
+		var size = self->block_size;
+
+		if (min_size > size) {
+			size = min_size;
+		}
+
+		var block: ArenaBlock* = self->backing.alloc(@sizeof(ArenaBlock));
+
+		if (block == null) {
+			@panic("arena failed to allocate block header");
+		}
+
+		const data = self->backing.alloc(size);
+
+		if (data == null) {
+			@panic("arena failed to allocate block data");
+		}
+
+		block->data = data;
+		block->cap = size;
+		block->used = 0;
+		block->next = self->current;
+
+		self->current = block;
+
+		return block;
+	}
+
+	pub fn alloc(&self, size: usize) void* {
+		return self->alloc_aligned(size, ARENA_DEFAULT_ALIGNMENT);
+	}
+
+	pub fn alloc_aligned(&self, size: usize, align: usize) void* {
+		@assert(is_power_of_two(align), "alignment must be power of two");
+
+		if (self->current == null) {
+			self->new_block(size + align);
+		}
+
+		var block = self->current;
+
+		var current_addr = @cast(uintptr, block->data) + block->used;
+		var aligned = align_up(current_addr, align);
+		var new_used = (aligned - @cast(uintptr, block->data)) + size;
+
+		if (new_used > block->cap) {
+			block = self->new_block(size + align);
+
+			current_addr = @cast(uintptr, block->data) + block->used;
+			aligned = align_up(current_addr, align);
+			new_used = (aligned - @cast(uintptr, block->data)) + size;
+		}
+
+		block->used = new_used;
+
+		return @cast(void*, aligned);
+	}
+
+	pub fn alloc_zeroed(&self, size: usize) void* {
+		const ptr = self->alloc(size);
+
+		if (ptr != null) {
+			@memset(ptr, 0, size);
+		}
+
+		return ptr;
+	}
+
+	pub fn realloc(&self, ptr: void*, size: usize) void* {
+		return self->alloc(size);
+	}
+
+	pub fn free(&self, ptr: void*) {
+	}
+
+	pub fn reset(&self) {
+		var block = self->current;
+
+		while (block != null) {
+			block->used = 0;
+			block = block->next;
+		}
+	}
+
+	pub fn deinit(&self) {
+		var block = self->current;
+
+		while (block != null) {
+			const next = block->next;
+
+			self->backing.free(block->data);
+			self->backing.free(@cast(void*, block));
+
+			block = next;
+		}
+
+		self->current = null;
+	}
 }
 
 pub struct BumpAllocator : Allocator {


### PR DESCRIPTION
## Summary

Completes the `Map` and `ArenaAllocator` items of the STDLIB checklist and adds a hashing module. While implementing these, three compiler bugs that blocked the work were discovered and fixed.

## stdlib additions

- **`stdlib/hash.cyrus`** (new): FNV-1a (32/64), MurmurHash3 (x86 32-bit), plus `hash_bytes` / `hash_str` helpers. Outputs verified against reference vectors.
- **`stdlib/mem/index.cyrus`**: completes `ArenaAllocator` as a block-list arena over a backing allocator (`alloc`, `alloc_aligned`, `alloc_zeroed`, `realloc`, `free`, `reset`, `deinit`).
- **`stdlib/collections.cyrus`**: generic `HashMap<K, V>` using open addressing with linear probing, tombstone deletion and automatic growth (load factor 0.75). Type-safe `fn(K*)` hash/eq callbacks.

## Compiler fixes (each was a real blocker, no prior issue)

1. **Self-referential types** (`cir/lower.rs`): structs/enums with a pointer field to themselves (linked list, tree, arena block) caused a stack overflow during lowering because the pointee was expanded infinitely. Added a recursion guard that substitutes the in-progress named type behind a pointer with a shallow placeholder.
2. **Generic inference** (`analyzer/infer.rs`): `unify` had no arm for two identical `Plain` types, so a concrete first type-argument aborted structural unification of a `Named` type early and left later `InferVar` arguments unbound. This broke multi-parameter generic inference (one param from an argument, another from the annotation). Added a `(Plain, Plain)` arm.
3. **Logical operator chaining** (`parser/exprs.rs`): `&&` and `||` were wrongly treated as non-associative, so `a || b || c` was rejected. Removed them from the non-associative set; real comparison chaining (`a < b < c`) is still rejected.

## Testing

All 150 existing tests pass. New stdlib pieces verified manually (numeric and string keys, grow/rehash, update, remove; arena multi-block alloc and reset; hash reference vectors).
