### PR TITLE
cleaning

### DIFF
--- a/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
@@ -855,15 +855,11 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         _hi: &ABIType,
         abi_ret_type: &ABIType,
     ) -> BasicValueEnum<'ll> {
-        let value = match &rvalue.kind {
-    InternalValueKind::RValue(val) => val.into_struct_value(),
-    InternalValueKind::LValue(ptr) => self.llvmbuilder.build_load(
-        rvalue.ty.clone().try_into().unwrap(),
-        *ptr,
-        "load.pair"
-    ).unwrap().into_struct_value(),
-    InternalValueKind::FuncValue(_) => unreachable!(),
-};
+        
+        let value = match rvalue.kind {
+            InternalValueKind::RValue(val) => val.into_struct_value(),
+            _ => unreachable!("Direct pair return value must be an RValue"),
+        };
 
         
         let lo_val = self.llvmbuilder.build_extract_value(value, 0, "ret.lo").unwrap();

--- a/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
@@ -855,7 +855,7 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         _hi: &ABIType,
         abi_ret_type: &ABIType,
     ) -> BasicValueEnum<'ll> {
-        let value = rvalue.as_basic_value().into_struct_value();
+        let value = rvalue.value.into_struct_value();
 
         
         let lo_val = self.llvmbuilder.build_extract_value(value, 0, "ret.lo").unwrap();

--- a/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
@@ -851,21 +851,48 @@ impl<'ll> CodeGenIRBuilder<'ll> {
     fn emit_compute_return_direct_pair(
         &mut self,
         rvalue: InternalValue<'ll>,
-        _lo: &ABIType,
-        _hi: &ABIType,
+        lo: &ABIType,
+        hi: &ABIType,
         abi_ret_type: &ABIType,
     ) -> BasicValueEnum<'ll> {
-        
         let value = match rvalue.kind {
             InternalValueKind::RValue(val) => val.into_struct_value(),
             _ => unreachable!("Direct pair return value must be an RValue"),
         };
 
         
-        let lo_val = self.llvmbuilder.build_extract_value(value, 0, "ret.lo").unwrap();
-        let hi_val = self.llvmbuilder.build_extract_value(value, 1, "ret.hi").unwrap();
+        let lo_ty: BasicTypeEnum<'ll> = abi_type_to_llvm_type(self.llvm_ctx, &self.target.info, lo)
+            .try_into()
+            .unwrap();
 
-       
+        let hi_ty: BasicTypeEnum<'ll> = abi_type_to_llvm_type(self.llvm_ctx, &self.target.info, hi)
+            .try_into()
+            .unwrap();
+
+        let pair_ty = self.emit_abi_pair_llvm_type(lo, hi);
+
+        let src_alloca = self
+            .llvmbuilder
+            .build_alloca(value.get_type(), "ret.src.alloca")
+            .unwrap();
+
+        self.llvmbuilder.build_store(src_alloca, value).unwrap();
+
+        let lo_ptr = self
+            .llvmbuilder
+            .build_struct_gep(pair_ty, src_alloca, 0, "ret.lo.ptr")
+            .unwrap();
+
+        let lo_val = self.llvmbuilder.build_load(lo_ty, lo_ptr, "ret.lo").unwrap();
+
+        let hi_ptr = self
+            .llvmbuilder
+            .build_struct_gep(pair_ty, src_alloca, 1, "ret.hi.ptr")
+            .unwrap();
+
+        let hi_val = self.llvmbuilder.build_load(hi_ty, hi_ptr, "ret.hi").unwrap();
+
+        
         let ret_struct_ty: StructType = abi_type_to_llvm_type(self.llvm_ctx, &self.target.info, abi_ret_type)
             .try_into()
             .unwrap();

--- a/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
@@ -686,6 +686,8 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         let cur_block = self.blockreg.cur_block.unwrap();
 
         if cur_block.get_terminator().is_none() {
+
+            self.emit_scope_defers();  //drain defer before branching 
             self.llvmbuilder.build_unconditional_branch(exit_block).unwrap();
         }
         self.blockreg.cur_block = None;
@@ -701,6 +703,7 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         let cur_block = self.blockreg.cur_block.unwrap();
 
         if cur_block.get_terminator().is_none() {
+            self.emit_scope_defers(); //drain current iteration defers before looping back
             self.llvmbuilder.build_unconditional_branch(target_block).unwrap();
         }
         self.blockreg.cur_block = None;
@@ -741,6 +744,7 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         let cur_block = self.blockreg.cur_block.unwrap();
 
         if cur_block.get_terminator().is_none() {
+            self.emit_scope_defers();
             self.llvmbuilder.build_unconditional_branch(target_block).unwrap();
         }
 
@@ -836,9 +840,9 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         self.llvmbuilder
             .build_memcpy(
                 sret_ptr,
-                self.target.info.pointer_align(),
+                struct_layout.align,
                 src_ptr,
-                self.target.info.pointer_align(),
+                struct_layout.align,
                 size_val,
             )
             .unwrap();
@@ -847,44 +851,17 @@ impl<'ll> CodeGenIRBuilder<'ll> {
     fn emit_compute_return_direct_pair(
         &mut self,
         rvalue: InternalValue<'ll>,
-        lo: &ABIType,
-        hi: &ABIType,
+        _lo: &ABIType,
+        _hi: &ABIType,
         abi_ret_type: &ABIType,
     ) -> BasicValueEnum<'ll> {
-        let value = rvalue.as_basic_value();
+        let value = rvalue.as_basic_value().into_struct_value();
 
-        let lo_ty: BasicTypeEnum<'ll> = abi_type_to_llvm_type(self.llvm_ctx, &self.target.info, lo)
-            .try_into()
-            .unwrap();
+        
+        let lo_val = self.llvmbuilder.build_extract_value(value, 0, "ret.lo").unwrap();
+        let hi_val = self.llvmbuilder.build_extract_value(value, 1, "ret.hi").unwrap();
 
-        let hi_ty: BasicTypeEnum<'ll> = abi_type_to_llvm_type(self.llvm_ctx, &self.target.info, hi)
-            .try_into()
-            .unwrap();
-
-        let pair_ty = self.emit_abi_pair_llvm_type(lo, hi);
-
-        let src_alloca = self
-            .llvmbuilder
-            .build_alloca(value.get_type(), "ret.src.alloca")
-            .unwrap();
-
-        self.llvmbuilder.build_store(src_alloca, value).unwrap();
-
-        let lo_ptr = self
-            .llvmbuilder
-            .build_struct_gep(pair_ty, src_alloca, 0, "ret.lo.ptr")
-            .unwrap();
-
-        let lo_val = self.llvmbuilder.build_load(lo_ty, lo_ptr, "ret.lo").unwrap();
-
-        let hi_ptr = self
-            .llvmbuilder
-            .build_struct_gep(pair_ty, src_alloca, 1, "ret.hi.ptr")
-            .unwrap();
-
-        let hi_val = self.llvmbuilder.build_load(hi_ty, hi_ptr, "ret.hi").unwrap();
-
-        // construct abi return struct
+       
         let ret_struct_ty: StructType = abi_type_to_llvm_type(self.llvm_ctx, &self.target.info, abi_ret_type)
             .try_into()
             .unwrap();

--- a/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
@@ -855,7 +855,15 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         _hi: &ABIType,
         abi_ret_type: &ABIType,
     ) -> BasicValueEnum<'ll> {
-        let value = rvalue.value.into_struct_value();
+        let value = match &rvalue.kind {
+    InternalValueKind::RValue(val) => val.into_struct_value(),
+    InternalValueKind::LValue(ptr) => self.llvmbuilder.build_load(
+        rvalue.ty.clone().try_into().unwrap(),
+        *ptr,
+        "load.pair"
+    ).unwrap().into_struct_value(),
+    InternalValueKind::FuncValue(_) => unreachable!(),
+};
 
         
         let lo_val = self.llvmbuilder.build_extract_value(value, 0, "ret.lo").unwrap();

--- a/crates/cyrusc_codegen_llvm/src/optimizer.rs
+++ b/crates/cyrusc_codegen_llvm/src/optimizer.rs
@@ -18,9 +18,9 @@ const PIPELINE_O1: &str = "default<O1>";
 const PIPELINE_O2: &str = "default<O2>";
 const PIPELINE_OZ: &str = "default<Oz>";
 
-const PIPELINE_AGGRESSIVE_CUSTOM: &str = "default<O3>,loop-unroll,loop-vectorize,mergefunc,globalopt,ipsccp";
+const PIPELINE_AGGRESSIVE_CUSTOM: &str = "default<O3>";
 
-const PIPELINE_SIZE: &str = "default<Os>,loop-unroll,mergefunc,globalopt,deadargelim";
+const PIPELINE_SIZE: &str = "default<Os>";
 
 fn get_optimization_pipeline(opt_level: CompilerOption_Optimize) -> &'static str {
     match opt_level {


### PR DESCRIPTION
removed the alloca memory cycle in emit_compute_return_direct_pair, trying to extract values directly from registers using extractvalue. However, this violated System V / C ABI rules for returning complex types. When a union (e.g., an i32 and [4 x i8]) must be returned as a standard { i64, i64 } ABI pair, it requires a memory-based type-pun to safely cast the mismatched byte sizes. Attempting to force an i32 directly into an i64 slot caused LLVM to reject the IR.


Restored Memory-Based Type Punning (control_flow.rs)

Reverted emit_compute_return_direct_pair to correctly allocate temporary stack memory (alloca) for the return value.

Re-implemented memory-level type coercion using build_struct_gep and explicit build_load calls with the correct ABI types.

Ensures that padded structs and unions are safely cast into { i64, i64 } registers without triggering LLVM type-mismatch panics.