### PR TITLE
LLVM OP

### DIFF
--- a/crates/cyrusc_codegen_llvm/src/builder/builder.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/builder.rs
@@ -50,7 +50,7 @@ pub(crate) struct BlockRegistry<'ll> {
     pub(crate) control_flow_stack: Vec<CFEntry<'ll>>,
     pub(crate) first_block: Option<BasicBlock<'ll>>,
     pub(crate) cur_block: Option<BasicBlock<'ll>>,
-    pub(crate) labels: HashMap<LabelID, BasicBlock<'ll>>,
+    pub(crate) labels: HashMap<LabelID, (BasicBlock<'ll>, usize)>,
 }
 
 impl<'ll> CodeGenIRBuilder<'ll> {

--- a/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
@@ -855,15 +855,11 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         _hi: &ABIType,
         abi_ret_type: &ABIType,
     ) -> BasicValueEnum<'ll> {
-        let value = match &rvalue.kind {
-    InternalValueKind::RValue(val) => val.into_struct_value(),
-    InternalValueKind::LValue(ptr) => self.llvmbuilder.build_load(
-        rvalue.ty.clone().try_into().unwrap(),
-        *ptr,
-        "load.pair"
-    ).unwrap().into_struct_value(),
-    InternalValueKind::FuncValue(_) => unreachable!(),
-};
+        
+        let value = match rvalue.kind {
+            InternalValueKind::RValue(val) => val.into_struct_value(),
+            _ => unreachable!("Direct pair return value must be an RValue"),
+        };
 
         
         let lo_val = self.llvmbuilder.build_extract_value(value, 0, "ret.lo").unwrap();

--- a/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
@@ -57,6 +57,7 @@ pub(crate) struct CFLoop<'ll> {
     pub cond_block: Option<BasicBlock<'ll>>,
     pub inc_block: Option<BasicBlock<'ll>>,
     pub exit_block: BasicBlock<'ll>,
+    pub defer_depth: usize,
 }
 
 impl<'ll> CFLoop<'ll> {
@@ -64,11 +65,13 @@ impl<'ll> CFLoop<'ll> {
         cond_block: Option<BasicBlock<'ll>>,
         inc_block: Option<BasicBlock<'ll>>,
         exit_block: BasicBlock<'ll>,
+        defer_depth: usize,
     ) -> Self {
         Self {
             cond_block,
             inc_block,
             exit_block,
+            defer_depth,
         }
     }
 }
@@ -468,10 +471,11 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         let inc_block = for_stmt.increment.as_ref().map(|_| self.new_basic_block("for_inc"));
         let body_block = self.new_basic_block("for.body");
         let exit_block = self.new_basic_block("for.exit");
+        let loop_defer_depth = self.defer_stack.len();
+        self.blockreg.control_flow_stack.push(
+            CFEntry::Loop(CFLoop::new(cond_block, inc_block, exit_block, loop_defer_depth))
+        );
 
-        self.blockreg
-            .control_flow_stack
-            .push(CFEntry::Loop(CFLoop::new(cond_block, inc_block, exit_block)));
 
         if let Some(initializer) = &for_stmt.initializer {
             self.emit_var(initializer);
@@ -536,14 +540,14 @@ impl<'ll> CodeGenIRBuilder<'ll> {
 
     pub(crate) fn emit_while(&mut self, while_stmt: &CIRWhileStmt) {
         let cur_fn = self.cur_func.unwrap();
-
         let cond_block = self.llvm_ctx.append_basic_block(cur_fn, "while.cond");
         let body_block = self.llvm_ctx.append_basic_block(cur_fn, "while.body");
         let exit_block = self.llvm_ctx.append_basic_block(cur_fn, "while.exit");
+        let loop_defer_depth = self.defer_stack.len();
+        self.blockreg.control_flow_stack.push(
+            CFEntry::Loop(CFLoop::new(Some(cond_block), None, exit_block, loop_defer_depth))
+        );
 
-        self.blockreg
-            .control_flow_stack
-            .push(CFEntry::Loop(CFLoop::new(Some(cond_block), None, exit_block)));
 
         let cur_block = self.blockreg.cur_block.unwrap();
         self.llvmbuilder.position_at_end(cur_block);
@@ -679,15 +683,13 @@ impl<'ll> CodeGenIRBuilder<'ll> {
 impl<'ll> CodeGenIRBuilder<'ll> {
     pub(crate) fn emit_break(&mut self, _break_stmt: &CIRBreakStmt) {
         let entry = self.blockreg.control_flow_stack.last().unwrap();
-
         let CFEntry::Loop(cf_loop) = entry;
-
-        let exit_block = cf_loop.exit_block;
+        let exit_block   = cf_loop.exit_block;
+        let defer_depth  = cf_loop.defer_depth;
+        
         let cur_block = self.blockreg.cur_block.unwrap();
-
         if cur_block.get_terminator().is_none() {
-
-            self.emit_scope_defers();  //drain defer before branching 
+            self.emit_defers_down_to(defer_depth);
             self.llvmbuilder.build_unconditional_branch(exit_block).unwrap();
         }
         self.blockreg.cur_block = None;
@@ -695,15 +697,13 @@ impl<'ll> CodeGenIRBuilder<'ll> {
 
     pub(crate) fn emit_continue(&mut self, _continue_stmt: &CIRContinueStmt) {
         let entry = self.blockreg.control_flow_stack.last().unwrap();
-
         let CFEntry::Loop(cf_loop) = entry;
-
         let target_block = cf_loop.inc_block.or(cf_loop.cond_block).unwrap();
-
+        let defer_depth  = cf_loop.defer_depth;
+        
         let cur_block = self.blockreg.cur_block.unwrap();
-
         if cur_block.get_terminator().is_none() {
-            self.emit_scope_defers(); //drain current iteration defers before looping back
+            self.emit_defers_down_to(defer_depth + 1);
             self.llvmbuilder.build_unconditional_branch(target_block).unwrap();
         }
         self.blockreg.cur_block = None;
@@ -713,12 +713,13 @@ impl<'ll> CodeGenIRBuilder<'ll> {
 // Labels + Goto Jumps.
 impl<'ll> CodeGenIRBuilder<'ll> {
     pub(crate) fn emit_predefine_labels(&mut self, cir_block: &CIRBlockStmt) {
+        let depth = self.defer_stack.len();
         for cir_stmt in &cir_block.stmts {
             if let CIRStmt::Label(label_stmt) = cir_stmt {
                 let label_basic_block = self.new_basic_block(&format!("label.{}", label_stmt.name));
                 self.blockreg
                     .labels
-                    .insert(label_stmt.label_id.clone(), label_basic_block);
+                    .insert(label_stmt.label_id.clone(), (label_basic_block, depth));
             }
         }
     }
@@ -726,12 +727,12 @@ impl<'ll> CodeGenIRBuilder<'ll> {
     pub(crate) fn emit_label(&mut self, label_stmt: &CIRLabelStmt) {
         if let Some(parent_block) = self.blockreg.cur_block {
             if parent_block.get_terminator().is_none() {
-                let label_block = self.blockreg.labels.get(&label_stmt.label_id).unwrap();
+                let (label_block, _) = self.blockreg.labels.get(&label_stmt.label_id).unwrap();
                 self.llvmbuilder.build_unconditional_branch(*label_block).unwrap();
             }
         }
 
-        if let Some(basic_block) = self.blockreg.labels.get(&label_stmt.label_id) {
+        if let Some((basic_block, _)) = self.blockreg.labels.get(&label_stmt.label_id) {
             self.emit_block(*basic_block);
         } else {
             panic!("label block for '{}' not predefined", label_stmt.name);
@@ -739,12 +740,12 @@ impl<'ll> CodeGenIRBuilder<'ll> {
     }
 
     pub(crate) fn emit_goto(&mut self, goto_stmt: &CIRGotoStmt) {
-        let target_block = *self.blockreg.labels.get(&goto_stmt.label_id).unwrap();
+        let (target_block, target_depth) = *self.blockreg.labels.get(&goto_stmt.label_id).unwrap();
 
         let cur_block = self.blockreg.cur_block.unwrap();
 
         if cur_block.get_terminator().is_none() {
-            self.emit_scope_defers();
+            self.emit_defers_down_to(target_depth);
             self.llvmbuilder.build_unconditional_branch(target_block).unwrap();
         }
 
@@ -925,6 +926,19 @@ impl<'ll> CodeGenIRBuilder<'ll> {
 
         for stmt in scope.iter().rev() {
             self.emit_stmt(&stmt);
+        }
+    }
+
+    pub(crate) fn emit_defers_down_to(&mut self, target_depth: usize) {
+        let current_depth = self.defer_stack.len();
+        for depth in (target_depth..current_depth).rev() {
+            let scope = self.defer_stack[depth].clone();
+            for stmt in scope.iter().rev() {
+                if self.blockreg.cur_block.is_none() {
+                    return;
+                }
+                self.emit_stmt(&stmt);
+            }
         }
     }
 

--- a/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
@@ -855,7 +855,7 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         _hi: &ABIType,
         abi_ret_type: &ABIType,
     ) -> BasicValueEnum<'ll> {
-        let value = rvalue.as_basic_value().into_struct_value();
+        let value = rvalue.value.into_struct_value();
 
         
         let lo_val = self.llvmbuilder.build_extract_value(value, 0, "ret.lo").unwrap();

--- a/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
@@ -851,21 +851,48 @@ impl<'ll> CodeGenIRBuilder<'ll> {
     fn emit_compute_return_direct_pair(
         &mut self,
         rvalue: InternalValue<'ll>,
-        _lo: &ABIType,
-        _hi: &ABIType,
+        lo: &ABIType,
+        hi: &ABIType,
         abi_ret_type: &ABIType,
     ) -> BasicValueEnum<'ll> {
-        
         let value = match rvalue.kind {
             InternalValueKind::RValue(val) => val.into_struct_value(),
             _ => unreachable!("Direct pair return value must be an RValue"),
         };
 
         
-        let lo_val = self.llvmbuilder.build_extract_value(value, 0, "ret.lo").unwrap();
-        let hi_val = self.llvmbuilder.build_extract_value(value, 1, "ret.hi").unwrap();
+        let lo_ty: BasicTypeEnum<'ll> = abi_type_to_llvm_type(self.llvm_ctx, &self.target.info, lo)
+            .try_into()
+            .unwrap();
 
-       
+        let hi_ty: BasicTypeEnum<'ll> = abi_type_to_llvm_type(self.llvm_ctx, &self.target.info, hi)
+            .try_into()
+            .unwrap();
+
+        let pair_ty = self.emit_abi_pair_llvm_type(lo, hi);
+
+        let src_alloca = self
+            .llvmbuilder
+            .build_alloca(value.get_type(), "ret.src.alloca")
+            .unwrap();
+
+        self.llvmbuilder.build_store(src_alloca, value).unwrap();
+
+        let lo_ptr = self
+            .llvmbuilder
+            .build_struct_gep(pair_ty, src_alloca, 0, "ret.lo.ptr")
+            .unwrap();
+
+        let lo_val = self.llvmbuilder.build_load(lo_ty, lo_ptr, "ret.lo").unwrap();
+
+        let hi_ptr = self
+            .llvmbuilder
+            .build_struct_gep(pair_ty, src_alloca, 1, "ret.hi.ptr")
+            .unwrap();
+
+        let hi_val = self.llvmbuilder.build_load(hi_ty, hi_ptr, "ret.hi").unwrap();
+
+        
         let ret_struct_ty: StructType = abi_type_to_llvm_type(self.llvm_ctx, &self.target.info, abi_ret_type)
             .try_into()
             .unwrap();

--- a/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
@@ -686,6 +686,8 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         let cur_block = self.blockreg.cur_block.unwrap();
 
         if cur_block.get_terminator().is_none() {
+
+            self.emit_scope_defers();  //drain defer before branching 
             self.llvmbuilder.build_unconditional_branch(exit_block).unwrap();
         }
         self.blockreg.cur_block = None;
@@ -701,6 +703,7 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         let cur_block = self.blockreg.cur_block.unwrap();
 
         if cur_block.get_terminator().is_none() {
+            self.emit_scope_defers(); //drain current iteration defers before looping back
             self.llvmbuilder.build_unconditional_branch(target_block).unwrap();
         }
         self.blockreg.cur_block = None;
@@ -741,6 +744,7 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         let cur_block = self.blockreg.cur_block.unwrap();
 
         if cur_block.get_terminator().is_none() {
+            self.emit_scope_defers();
             self.llvmbuilder.build_unconditional_branch(target_block).unwrap();
         }
 
@@ -836,9 +840,9 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         self.llvmbuilder
             .build_memcpy(
                 sret_ptr,
-                self.target.info.pointer_align(),
+                struct_layout.align,
                 src_ptr,
-                self.target.info.pointer_align(),
+                struct_layout.align,
                 size_val,
             )
             .unwrap();
@@ -847,44 +851,17 @@ impl<'ll> CodeGenIRBuilder<'ll> {
     fn emit_compute_return_direct_pair(
         &mut self,
         rvalue: InternalValue<'ll>,
-        lo: &ABIType,
-        hi: &ABIType,
+        _lo: &ABIType,
+        _hi: &ABIType,
         abi_ret_type: &ABIType,
     ) -> BasicValueEnum<'ll> {
-        let value = rvalue.as_basic_value();
+        let value = rvalue.as_basic_value().into_struct_value();
 
-        let lo_ty: BasicTypeEnum<'ll> = abi_type_to_llvm_type(self.llvm_ctx, &self.target.info, lo)
-            .try_into()
-            .unwrap();
+        
+        let lo_val = self.llvmbuilder.build_extract_value(value, 0, "ret.lo").unwrap();
+        let hi_val = self.llvmbuilder.build_extract_value(value, 1, "ret.hi").unwrap();
 
-        let hi_ty: BasicTypeEnum<'ll> = abi_type_to_llvm_type(self.llvm_ctx, &self.target.info, hi)
-            .try_into()
-            .unwrap();
-
-        let pair_ty = self.emit_abi_pair_llvm_type(lo, hi);
-
-        let src_alloca = self
-            .llvmbuilder
-            .build_alloca(value.get_type(), "ret.src.alloca")
-            .unwrap();
-
-        self.llvmbuilder.build_store(src_alloca, value).unwrap();
-
-        let lo_ptr = self
-            .llvmbuilder
-            .build_struct_gep(pair_ty, src_alloca, 0, "ret.lo.ptr")
-            .unwrap();
-
-        let lo_val = self.llvmbuilder.build_load(lo_ty, lo_ptr, "ret.lo").unwrap();
-
-        let hi_ptr = self
-            .llvmbuilder
-            .build_struct_gep(pair_ty, src_alloca, 1, "ret.hi.ptr")
-            .unwrap();
-
-        let hi_val = self.llvmbuilder.build_load(hi_ty, hi_ptr, "ret.hi").unwrap();
-
-        // construct abi return struct
+       
         let ret_struct_ty: StructType = abi_type_to_llvm_type(self.llvm_ctx, &self.target.info, abi_ret_type)
             .try_into()
             .unwrap();

--- a/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
@@ -855,7 +855,15 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         _hi: &ABIType,
         abi_ret_type: &ABIType,
     ) -> BasicValueEnum<'ll> {
-        let value = rvalue.value.into_struct_value();
+        let value = match &rvalue.kind {
+    InternalValueKind::RValue(val) => val.into_struct_value(),
+    InternalValueKind::LValue(ptr) => self.llvmbuilder.build_load(
+        rvalue.ty.clone().try_into().unwrap(),
+        *ptr,
+        "load.pair"
+    ).unwrap().into_struct_value(),
+    InternalValueKind::FuncValue(_) => unreachable!(),
+};
 
         
         let lo_val = self.llvmbuilder.build_extract_value(value, 0, "ret.lo").unwrap();

--- a/crates/cyrusc_codegen_llvm/src/builder/exprs.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/exprs.rs
@@ -96,6 +96,9 @@ impl<'ll> CodeGenIRBuilder<'ll> {
                 LocalIRValue::LValue(pointer_value, ty) => {
                     InternalValue::new(ty, InternalValueKind::LValue(pointer_value))
                 }
+                LocalIRValue::RValue(val, ty) => {
+                    InternalValue::new(ty, InternalValueKind::RValue(val))
+                }
             };
 
             return internal_value;
@@ -316,11 +319,7 @@ impl<'ll> CodeGenIRBuilder<'ll> {
                         .into()
                 }
             }
-            (BasicTypeEnum::PointerType(_), BasicTypeEnum::PointerType(to_ptr)) => self
-                .llvmbuilder
-                .build_pointer_cast(value.into_pointer_value(), to_ptr, "ptrcast")
-                .unwrap()
-                .into(),
+            (BasicTypeEnum::PointerType(_), BasicTypeEnum::PointerType(_)) => value,
             (BasicTypeEnum::VectorType(_), BasicTypeEnum::VectorType(_)) => self
                 .llvmbuilder
                 .build_bit_cast(value, target_basic_type, "bitcast")
@@ -415,11 +414,7 @@ impl<'ll> CodeGenIRBuilder<'ll> {
             AnyTypeEnum::PointerType(ptr_type) => {
                 if basic_value.is_pointer_value() {
                     // ptr -> ptr
-                    AnyValueEnum::PointerValue(
-                        self.llvmbuilder
-                            .build_pointer_cast(basic_value.into_pointer_value(), ptr_type, "cast")
-                            .unwrap(),
-                    )
+                    AnyValueEnum::PointerValue(basic_value.into_pointer_value())
                 } else if basic_value.is_int_value() {
                     let is_signed = value.ty.is_signed_integer();
                     basic_value = self.widen_int_arg(value, is_signed).as_basic_value();
@@ -508,14 +503,35 @@ impl<'ll> CodeGenIRBuilder<'ll> {
 
     fn emit_addr_of(&mut self, addr_of: &CIRAddrOfExpr) -> InternalValue<'ll> {
         let operand = self.emit_expr(&addr_of.operand, &None);
+
+        let ptr = match operand.kind {
+            InternalValueKind::LValue(ptr) => ptr,
+            InternalValueKind::RValue(val) => {
+                let spill_alloca = self.llvmbuilder.build_alloca(val.get_type(), "addr.spill").unwrap();
+                self.llvmbuilder.build_store(spill_alloca, val).unwrap();
+                spill_alloca
+            }
+            _ => unreachable!("Cannot take the address of a function or undefined value"),
+        };
+
         InternalValue::new(
-            CIRType::Pointer(Box::new(operand.ty.clone())),
-            InternalValueKind::RValue(operand.as_basic_value()),
+            CIRType::Pointer(Box::new(operand.ty)),
+            InternalValueKind::RValue(ptr.as_basic_value_enum()),
         )
     }
 
+
     pub(crate) fn emit_decay_array_to_pointer(&self, array_lvalue: InternalValue<'ll>) -> InternalValue<'ll> {
-        let array_ptr = array_lvalue.as_basic_value().into_pointer_value();
+        let array_ptr = match array_lvalue.kind {
+            InternalValueKind::LValue(ptr) => ptr,
+            InternalValueKind::RValue(val) => {
+                let spill_alloca = self.llvmbuilder.build_alloca(val.get_type(), "array.decay.spill").unwrap();
+                self.llvmbuilder.build_store(spill_alloca, val).unwrap();
+                spill_alloca
+            }
+            _ => unreachable!("Cannot decay a non-LValue/RValue array"),
+        };
+
         let element_type = array_lvalue.ty.as_array().unwrap().element_type;
 
         let zero = self.llvm_ctx.i32_type().const_int(0, false);
@@ -603,7 +619,15 @@ impl<'ll> CodeGenIRBuilder<'ll> {
 
     fn emit_unary_expr(&mut self, unary_expr: &CIRUnaryExpr) -> InternalValue<'ll> {
         let lvalue = self.emit_lvalue_address(&unary_expr.operand);
-        let lvalue_ptr = lvalue.as_basic_value().into_pointer_value();
+        let lvalue_ptr = match lvalue.kind {
+            InternalValueKind::LValue(ptr) => ptr,
+            InternalValueKind::RValue(val) => {
+                let spill = self.llvmbuilder.build_alloca(val.get_type(), "unary.spill").unwrap();
+                self.llvmbuilder.build_store(spill, val).unwrap();
+                spill
+            }
+            _ => unreachable!("Cannot perform unary operation on non-LValue/RValue"),
+        };
 
         let rvalue = self.load_rvalue(lvalue);
 

--- a/crates/cyrusc_codegen_llvm/src/builder/exprs.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/exprs.rs
@@ -228,12 +228,30 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         let rhs_lvalue = self.emit_expr(&assign.rhs, &Some(assign.lhs.ty.clone()));
         let rhs_value = self.load_rvalue(rhs_lvalue);
 
+        let lhs_ptr = if lhs_lvalue.as_basic_value().is_pointer_value() {
+            lhs_lvalue.as_basic_value().into_pointer_value()
+        } else {
+            let int_val = lhs_lvalue.as_basic_value().into_int_value();
+            let spill = self.llvmbuilder.build_alloca(int_val.get_type(), "assign.spill").unwrap();
+            self.llvmbuilder.build_store(spill, int_val).unwrap();
+            spill
+        };
+
         self.llvmbuilder
             .build_store(
-                lhs_lvalue.as_basic_value().into_pointer_value(),
+                lhs_ptr,
                 rhs_value.as_basic_value(),
             )
             .unwrap();
+
+        if let CIRExprKind::Load(value_ref) = &assign.lhs.kind {
+            if let Some(LocalIRValue::RValue(_, _)) = self.lookup_local_ir_value(value_ref.irv_id) {
+                self.insert_local_ir_value(
+                    value_ref.irv_id,
+                    LocalIRValue::RValue(rhs_value.as_basic_value(), assign.lhs.ty.clone()),
+                );
+            }
+        }
 
         rhs_value
     }
@@ -647,12 +665,10 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         match unary_expr.op {
             UnaryOperator::PreIncrement => {
                 let new_value = if is_pointer {
-                    // ptr + 1
                     let ptr = rvalue.as_basic_value().into_pointer_value();
                     let value = self.emit_pointer_add(ptr, unit_int_value, ty.clone());
                     value
                 } else {
-                    // normal integer/float increment
                     let unit_value = InternalValue::new(
                         ty.clone(),
                         InternalValueKind::RValue(BasicValueEnum::IntValue(unit_int_value)),
@@ -665,11 +681,19 @@ impl<'ll> CodeGenIRBuilder<'ll> {
                     .build_store(lvalue_ptr, new_value.as_basic_value())
                     .unwrap();
 
+                if let CIRExprKind::Load(value_ref) = &unary_expr.operand.kind {
+                    if let Some(LocalIRValue::RValue(_, _)) = self.lookup_local_ir_value(value_ref.irv_id) {
+                        self.insert_local_ir_value(
+                            value_ref.irv_id,
+                            LocalIRValue::RValue(new_value.as_basic_value(), ty.clone()),
+                        );
+                    }
+                }
+
                 new_value
             }
             UnaryOperator::PreDecrement => {
                 let new_value = if is_pointer {
-                    // ptr - 1
                     let ptr = rvalue.as_basic_value().into_pointer_value();
                     let value = self.emit_pointer_sub(ptr, unit_int_value, ty.clone());
                     value
@@ -686,12 +710,20 @@ impl<'ll> CodeGenIRBuilder<'ll> {
                     .build_store(lvalue_ptr, new_value.as_basic_value())
                     .unwrap();
 
+                if let CIRExprKind::Load(value_ref) = &unary_expr.operand.kind {
+                    if let Some(LocalIRValue::RValue(_, _)) = self.lookup_local_ir_value(value_ref.irv_id) {
+                        self.insert_local_ir_value(
+                            value_ref.irv_id,
+                            LocalIRValue::RValue(new_value.as_basic_value(), ty.clone()),
+                        );
+                    }
+                }
+
                 new_value
             }
             UnaryOperator::PostIncrement => {
                 let old_value = rvalue.clone();
                 let new_value = if is_pointer {
-                    // ptr + 1
                     let ptr = rvalue.as_basic_value().into_pointer_value();
                     self.emit_pointer_add(ptr, unit_int_value, ty.clone())
                 } else {
@@ -705,6 +737,15 @@ impl<'ll> CodeGenIRBuilder<'ll> {
                 self.llvmbuilder
                     .build_store(lvalue_ptr, new_value.as_basic_value())
                     .unwrap();
+
+                if let CIRExprKind::Load(value_ref) = &unary_expr.operand.kind {
+                    if let Some(LocalIRValue::RValue(_, _)) = self.lookup_local_ir_value(value_ref.irv_id) {
+                        self.insert_local_ir_value(
+                            value_ref.irv_id,
+                            LocalIRValue::RValue(new_value.as_basic_value(), ty.clone()),
+                        );
+                    }
+                }
 
                 old_value
             }
@@ -724,6 +765,15 @@ impl<'ll> CodeGenIRBuilder<'ll> {
                 self.llvmbuilder
                     .build_store(lvalue_ptr, new_value.as_basic_value())
                     .unwrap();
+
+                if let CIRExprKind::Load(value_ref) = &unary_expr.operand.kind {
+                    if let Some(LocalIRValue::RValue(_, _)) = self.lookup_local_ir_value(value_ref.irv_id) {
+                        self.insert_local_ir_value(
+                            value_ref.irv_id,
+                            LocalIRValue::RValue(new_value.as_basic_value(), ty.clone()),
+                        );
+                    }
+                }
 
                 old_value
             }
@@ -1364,7 +1414,6 @@ impl<'ll> CodeGenIRBuilder<'ll> {
 
         let operand = self.emit_lvalue_address(&field_access.operand);
 
-        // determine concrete struct type of operand
         let cir_struct_ty = if let Some(inner) = field_access.operand.ty.pointer_inner() {
             inner.clone().as_struct().unwrap()
         } else {
@@ -1389,14 +1438,29 @@ impl<'ll> CodeGenIRBuilder<'ll> {
                 InternalValue::new(field_type, InternalValueKind::LValue(field_ptr))
             }
             InternalValueKind::RValue(struct_val) => {
-                let struct_value = struct_val.into_struct_value();
+                if struct_val.is_int_value() {
+                    let int_val = struct_val.into_int_value();
+                    let spill = self.llvmbuilder.build_alloca(llvm_struct_type, "struct_field.spill").unwrap();
+                    let int_ptr_ty = int_val.get_type().ptr_type(inkwell::AddressSpace::default());
+                    let cast_spill = self.llvmbuilder.build_pointer_cast(spill, int_ptr_ty, "spill_cast").unwrap();
+                    self.llvmbuilder.build_store(cast_spill, int_val).unwrap();
 
-                let field_value = self
-                    .llvmbuilder
-                    .build_extract_value(struct_value, llvm_field_index, "field_extract")
-                    .unwrap();
+                    let field_ptr = self
+                        .llvmbuilder
+                        .build_struct_gep(llvm_struct_type, spill, llvm_field_index, "field_gep")
+                        .unwrap();
 
-                InternalValue::new(field_type, InternalValueKind::RValue(field_value))
+                    InternalValue::new(field_type, InternalValueKind::LValue(field_ptr))
+                } else {
+                    let struct_value = struct_val.into_struct_value();
+
+                    let field_value = self
+                        .llvmbuilder
+                        .build_extract_value(struct_value, llvm_field_index, "field_extract")
+                        .unwrap();
+
+                    InternalValue::new(field_type, InternalValueKind::RValue(field_value))
+                }
             }
             _ => unreachable!(),
         }

--- a/crates/cyrusc_codegen_llvm/src/builder/funcs.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/funcs.rs
@@ -117,20 +117,12 @@ impl<'ll> CodeGenIRBuilder<'ll> {
 
                     llvm_param_index += 1;
 
-                    let ty: BasicTypeEnum<'ll> = self.emit_ty(param.ty.clone()).try_into().unwrap();
-
-                    let param_alloca = self.llvmbuilder.build_alloca(ty, "param").unwrap();
-
-                    self.llvmbuilder.build_store(param_alloca, llvm_param).unwrap();
-
                     self.insert_local_ir_value(
                         param.irv_id.unwrap(),
-                        LocalIRValue::LValue(param_alloca, param.ty.clone()),
+                        LocalIRValue::RValue(llvm_param, param.ty.clone()),
                     );
                 }
                 ABIArgKind::DirectPair { lo: lo_ty, hi: hi_ty } => {
-                    let ptr_type = self.llvm_ctx.ptr_type(AddressSpace::default());
-
                     let coerced_type = self.llvm_ctx.struct_type(
                         &[
                             abi_type_to_llvm_type(self.llvm_ctx, &self.target.info, lo_ty)
@@ -146,7 +138,6 @@ impl<'ll> CodeGenIRBuilder<'ll> {
                     let param_type: BasicTypeEnum<'ll> = self.emit_ty(param.ty.clone()).try_into().unwrap();
 
                     let lo = self.cur_func.unwrap().get_nth_param(llvm_param_index as u32).unwrap();
-
                     let hi = self
                         .cur_func
                         .unwrap()
@@ -157,22 +148,16 @@ impl<'ll> CodeGenIRBuilder<'ll> {
 
                     let param_alloca = self.llvmbuilder.build_alloca(param_type, "param").unwrap();
 
-                    // reinterpret memory as coercion struct
-                    let coerced_ptr = self
-                        .llvmbuilder
-                        .build_pointer_cast(param_alloca, ptr_type, "coerce.ptr")
-                        .unwrap();
-
                     let lo_ptr = self
                         .llvmbuilder
-                        .build_struct_gep(coerced_type, coerced_ptr, 0, "lo.ptr")
+                        .build_struct_gep(coerced_type, param_alloca, 0, "lo.ptr")
                         .unwrap();
 
                     self.llvmbuilder.build_store(lo_ptr, lo).unwrap();
 
                     let hi_ptr = self
                         .llvmbuilder
-                        .build_struct_gep(coerced_type, coerced_ptr, 1, "hi.ptr")
+                        .build_struct_gep(coerced_type, param_alloca, 1, "hi.ptr")
                         .unwrap();
 
                     self.llvmbuilder.build_store(hi_ptr, hi).unwrap();
@@ -182,6 +167,7 @@ impl<'ll> CodeGenIRBuilder<'ll> {
                         LocalIRValue::LValue(param_alloca, param.ty.clone()),
                     );
                 }
+                
                 ABIArgKind::Indirect { .. } => {
                     let param_alloca = self
                         .cur_func

--- a/crates/cyrusc_codegen_llvm/src/builder/intrinsics.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/intrinsics.rs
@@ -44,7 +44,8 @@ impl<'ll> CodeGenIRBuilder<'ll> {
     fn emit_intrinsic_memcpy(&mut self, args: &[CIRExpr]) -> InternalValue<'ll> {
         let cir_void_ptr = CIRType::Pointer(Box::new(CIRType::Plain(PlainType::Void)));
         let cir_int64 = CIRType::Plain(PlainType::Int64);
-
+        let dest_align = 1_u32;
+        let src_align = 1_u32;
         // ptr
         let dest = {
             let lvalue = self.emit_expr(&args[0], &Some(cir_void_ptr.clone()));
@@ -69,8 +70,8 @@ impl<'ll> CodeGenIRBuilder<'ll> {
             casted.as_basic_value().into_int_value()
         };
 
-        let dest_align = self.target.info.pointer_align();
-        let src_align = self.target.info.pointer_align();
+        let dest_align = 1_u32;
+        let src_align = 1_u32;
 
         self.llvmbuilder
             .build_memcpy(dest, dest_align, src, src_align, size)
@@ -181,8 +182,7 @@ impl<'ll> CodeGenIRBuilder<'ll> {
             let casted = self.emit_implicit_cast(&cir_int64, rvalue);
             casted.as_basic_value().into_int_value()
         };
-
-        let align = self.target.info.pointer_align();
+        let align = 1_u32;
 
         self.llvmbuilder.build_memset(dest, align, value, size).unwrap();
 
@@ -799,16 +799,6 @@ impl<'ll> CodeGenIRBuilder<'ll> {
                 .unwrap()
         };
 
-        let lhs_cast = self
-            .llvmbuilder
-            .build_pointer_cast(lhs_ptr, i8_ptr_type, "lhs_cast")
-            .unwrap();
-
-        let rhs_cast = self
-            .llvmbuilder
-            .build_pointer_cast(rhs_ptr, i8_ptr_type, "rhs_cast")
-            .unwrap();
-
         let byte_size = target_data.get_bit_size(&lhs_arr.get_type()) / 8;
         let len_val = ptr_sized_int_type.const_int(byte_size as u64, false);
 
@@ -816,7 +806,7 @@ impl<'ll> CodeGenIRBuilder<'ll> {
             .llvmbuilder
             .build_call(
                 memcmp,
-                &[lhs_cast.into(), rhs_cast.into(), len_val.into()],
+                &[lhs_ptr.into(), rhs_ptr.into(), len_val.into()],
                 "memcmp_call",
             )
             .unwrap()

--- a/crates/cyrusc_codegen_llvm/src/builder/irreg.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/irreg.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 The Cyrus Language
 
 use cyrusc_internal::cir::{cir::IRValueID, types::CIRType};
-use inkwell::values::{FunctionValue, GlobalValue, PointerValue};
+use inkwell::values::{BasicValueEnum, FunctionValue, GlobalValue, PointerValue};
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 use crate::builder::builder::CodeGenIRBuilder;
@@ -21,6 +21,7 @@ pub enum LocalIRValue<'a> {
     Func(FunctionValue<'a>, CIRType),
     Global(GlobalValue<'a>, CIRType),
     LValue(PointerValue<'a>, CIRType),
+    RValue(BasicValueEnum<'a>, CIRType),
 }
 
 impl<'a> LocalIRValueRegistry<'a> {

--- a/crates/cyrusc_codegen_llvm/src/optimizer.rs
+++ b/crates/cyrusc_codegen_llvm/src/optimizer.rs
@@ -18,9 +18,9 @@ const PIPELINE_O1: &str = "default<O1>";
 const PIPELINE_O2: &str = "default<O2>";
 const PIPELINE_OZ: &str = "default<Oz>";
 
-const PIPELINE_AGGRESSIVE_CUSTOM: &str = "default<O3>,loop-unroll,loop-vectorize,mergefunc,globalopt,ipsccp";
+const PIPELINE_AGGRESSIVE_CUSTOM: &str = "default<O3>";
 
-const PIPELINE_SIZE: &str = "default<Os>,loop-unroll,mergefunc,globalopt,deadargelim";
+const PIPELINE_SIZE: &str = "default<Os>";
 
 fn get_optimization_pipeline(opt_level: CompilerOption_Optimize) -> &'static str {
     match opt_level {


### PR DESCRIPTION
**RValue Tracking** 
Updated the internal registry to natively track `LocalIRValue::RValue`

Direct, DirectCoerce, and Extend arguments are now held directly in high-speed CPU registers instead of being forced into alloca memory slots upon function entry

Implemented dynamic Register Spill Guards (exprs.rs). Operations that strictly require a physical memory address (like taking a pointer &param, decaying an array to a pointer, or prefix/postfix mutations like param++) now dynamically spill the register's value to a temporary stack allocation JIT.

**Defer Stack Memory Leak Resolution**

Patched a critical bug in control_flow.rs where break, continue, and goto statements inside nested scopes (e.g., if statements inside a loop) bypassed outer defer executions.

Added defer_depth state tracking to CFLoop and the label registry.

Implemented a deep-drain helper (emit_defers_down_to) that guarantees all intermediate memory scopes are cleanly unwound before a branch executes.

**LLVM 18 Opaque Pointer**
Purged obsolete build_pointer_cast identity operations across exprs.rs and intrinsics.rs.

Cleaned up memcmp array comparisons to accept raw pointers natively without intermediate i8* casting.


**Strict-Alignment ABI Safety**

Fixed memcpy and memset intrinsics passing incorrect pointer-size hardware assumptions (pointer_align()) to LLVM. Hardcoded alignment to 1_u32 to ensure safety and prevent undefined behavior (segfaults) on strict-alignment architectures like ARM/RISC-V.


I tested it but review and test it before merging