### PR TITLE
ABI Regressions/Resolver Forward-References

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,14 @@
 JOBS     ?= 24
 PROFILE  ?= debug
 
+ifeq ($(OS),Windows_NT)
+	EXE = .exe
+	PY_CMD = python
+else
+	EXE = 
+	PY_CMD = python3
+endif
+
 INPUT    ?= ./tmp/main.cyrus
 STDLIB   ?= ./stdlib
 LLVM_OUT ?= ./tmp/llvmir
@@ -11,7 +19,7 @@ CIR_DUMP_OUT ?= ./tmp/cir_dump
 ARGS     ?=
 
 TARGET_DIR = ./target/$(PROFILE)
-COMPILER   = $(TARGET_DIR)/cyrus
+COMPILER   = $(TARGET_DIR)/cyrus$(EXE)
 
 ifeq ($(PROFILE),release)
 	CARGO_PROFILE_FLAG = --release
@@ -61,15 +69,15 @@ build:
 test: build testsuite
 	$(CARGO_TEST) --all $(ARGS)
 
-testsuite:
-	python3 ./tests/test_suite.py \
+testsuite: build
+	$(PY_CMD) ./tests/test_suite.py \
 		-d tests \
 		--output ./tmp/tests \
 		--compiler $(COMPILER) \
 		--flags "--stdlib=$(STDLIB) --quiet"
 
-testsuite-fail:
-	python3 ./tests/test_suite.py \
+testsuite-fail: build
+	$(PY_CMD) ./tests/test_suite.py \
 		-d tests \
 		--output ./tmp/tests \
 		--compiler $(COMPILER) \

--- a/crates/cyrusc_asan_wrapper/build.rs
+++ b/crates/cyrusc_asan_wrapper/build.rs
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: MIT
-// Copyright (c) 2026 The Cyrus Language
 use std::env;
+use std::fs;
+use std::path::Path;
 use std::process::Command;
 
 fn main() {
@@ -9,25 +9,49 @@ fn main() {
     println!("cargo:rerun-if-env-changed=LLVM_CONFIG");
     println!("cargo:rerun-if-env-changed=GLIBC_INCLUDE_PATH");
 
+    let is_windows = cfg!(target_os = "windows");
+    let llvm_config = env::var("LLVM_CONFIG").unwrap_or_else(|_| "llvm-config".to_string());
+
+    let llvm_config_ok = if is_windows {
+        false
+    } else {
+        match Command::new(&llvm_config).arg("--cxxflags").output() {
+            Ok(output) => output.status.success(),
+            Err(_) => false,
+        }
+    };
+
+    if !llvm_config_ok {
+        println!("cargo:warning=llvm-config not found or target is Windows. Skipping C++ compilation of ASan wrapper and using stub.");
+        let out_dir = env::var("OUT_DIR").unwrap();
+        let dummy_path = Path::new(&out_dir).join("asan_dummy.cpp");
+        let dummy_content = "extern \"C\" {\n    typedef struct {\n        bool address_sanitize;\n        bool thread_sanitize;\n        bool mem_sanitize;\n        bool hwaddress_sanitize;\n        bool recover;\n        bool asan_use_after_scope;\n        bool asan_use_after_return;\n    } SanitizerOptions;\n    void run_sanitizer_passes(void* module_ref, void* tm_ref, int opt_level, SanitizerOptions opts) {}\n}";
+        fs::write(&dummy_path, dummy_content).unwrap();
+        cc::Build::new()
+            .cpp(true)
+            .file(dummy_path)
+            .warnings(false)
+            .compile("cyrusc_asan_wrapper");
+        return;
+    }
+
     let cpp_file = "src/asan_wrapper.cpp";
     println!("cargo:rerun-if-changed={}", cpp_file);
 
     let cxx = env::var("CXX").unwrap_or_else(|_| "clang++".to_string());
 
-    let llvm_config = env::var("LLVM_CONFIG").unwrap_or_else(|_| "llvm-config".to_string());
-
-    let cxxflags = Command::new(&llvm_config)
+    let cxxflags_output = Command::new(&llvm_config)
         .arg("--cxxflags")
         .output()
         .expect("Failed to run llvm-config --cxxflags");
-    let cxxflags = String::from_utf8(cxxflags.stdout).expect("llvm-config --cxxflags returned invalid UTF-8.");
+    let cxxflags = String::from_utf8(cxxflags_output.stdout).expect("llvm-config --cxxflags returned invalid UTF-8.");
 
-    let ldflags = Command::new(&llvm_config)
+    let ldflags_output = Command::new(&llvm_config)
         .args(["--ldflags", "--system-libs", "--libs", "core", "passes"])
         .output()
         .expect("Failed to run llvm-config for ldflags");
 
-    let ldflags = String::from_utf8(ldflags.stdout).unwrap();
+    let ldflags = String::from_utf8(ldflags_output.stdout).unwrap();
 
     for token in ldflags.split_whitespace() {
         if token.starts_with("-L") {

--- a/crates/cyrusc_codegen_llvm/src/builder/exprs.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/exprs.rs
@@ -234,12 +234,12 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         let lhs_ptr = if lhs_lvalue.as_basic_value().is_pointer_value() {
             lhs_lvalue.as_basic_value().into_pointer_value()
         } else {
-            let int_val = lhs_lvalue.as_basic_value().into_int_value();
+            let reg_val = lhs_lvalue.as_basic_value();
             let spill = self
                 .llvmbuilder
-                .build_alloca(int_val.get_type(), "assign.spill")
+                .build_alloca(reg_val.get_type(), "assign.spill")
                 .unwrap();
-            self.llvmbuilder.build_store(spill, int_val).unwrap();
+            self.llvmbuilder.build_store(spill, reg_val).unwrap();
             spill
         };
 
@@ -1449,17 +1449,20 @@ impl<'ll> CodeGenIRBuilder<'ll> {
                 InternalValue::new(field_type, InternalValueKind::LValue(field_ptr))
             }
             InternalValueKind::RValue(struct_val) => {
-                // TODO: This can be optimized via extracting bits from the integer at the correct offset
-                // But only if ABI representation is integer (must be performed strictly).
-
-                if struct_val.is_int_value() {
-                    let int_val = struct_val.into_int_value();
+                if struct_val.is_int_value() || struct_val.is_float_value() {
                     let spill = self
                         .llvmbuilder
                         .build_alloca(llvm_struct_type, "struct_field.spill")
                         .unwrap();
-
-                    self.llvmbuilder.build_store(spill, int_val).unwrap();
+                    let cast_ptr = self
+                        .llvmbuilder
+                        .build_pointer_cast(
+                            spill,
+                            struct_val.get_type().ptr_type(inkwell::AddressSpace::default()),
+                            "spill.cast",
+                        )
+                        .unwrap();
+                    self.llvmbuilder.build_store(cast_ptr, struct_val).unwrap();
 
                     let field_ptr = self
                         .llvmbuilder

--- a/crates/cyrusc_resolver/src/traverse.rs
+++ b/crates/cyrusc_resolver/src/traverse.rs
@@ -824,24 +824,22 @@ impl<'a> Resolver<'a> {
 
     fn resolve_typedef(&mut self, typedef: &ASTTypedefStmt) -> Option<TypedStmt> {
         let symbol_id = self.lookup_symbol_id(self.current_scope.unwrap(), &typedef.ident.value)?;
-
         let generic_params = self.resolve_generic_params(&typedef.generic_params)?;
-
         self.with_generic_scope(&generic_params.clone(), |this| {
-            let sema_type = this.resolve_type(typedef.type_spec.clone(), typedef.loc)?;
-
             let typedef_decl_id = this.decl_tables.insert_typedef(TypedefDecl {
                 name: typedef.ident.as_string(),
                 generic_params: generic_params.clone(),
-                ty: Box::new(sema_type.clone()),
+                ty: Box::new(SemaType::Placeholder),
                 vis: typedef.vis.clone(),
                 loc: typedef.loc,
             });
-
             this.with_global_symbol_mut(symbol_id, |symbol_entry| {
                 symbol_entry.kind = SymbolEntryKind::Typedef(typedef_decl_id)
             });
-
+            let sema_type = this.resolve_type(typedef.type_spec.clone(), typedef.loc)?;
+            this.decl_tables.with_typedef_decl_mut(typedef_decl_id, |decl| {
+                decl.ty = Box::new(sema_type.clone());
+            });
             Some(TypedStmt::Typedef(TypedTypedefStmt {
                 typedef_decl_id,
                 name: typedef.ident.as_string(),

--- a/tests/issues/anonymous_recursive_type.cyrus
+++ b/tests/issues/anonymous_recursive_type.cyrus
@@ -1,0 +1,11 @@
+// @stdout: ok
+
+import std::libc{printf};
+
+type XX = struct {
+    value: XX*
+};
+
+pub fn main() {
+    printf("ok\n");
+}

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -46,14 +46,11 @@ def unique_name(path: Path) -> str:
 
 
 def build_and_run(file_path, metadata, compiler_path, compiler_flags, output_dir):
-    # isolate temp per test
     with tempfile.TemporaryDirectory() as tmpdir:
         tmpdir = Path(tmpdir)
-
-        output_binary = tmpdir / unique_name(file_path)
-
+        suffix = ".exe" if os.name == "nt" else ""
+        output_binary = tmpdir / f"{unique_name(file_path)}{suffix}"
         output_binary.parent.mkdir(parents=True, exist_ok=True)
-
         env = os.environ.copy()
         env["TMPDIR"] = str(tmpdir)
         env["TEMP"] = str(tmpdir)
@@ -95,10 +92,9 @@ def build_and_run(file_path, metadata, compiler_path, compiler_flags, output_dir
             env=env
         )
 
-        actual_stdout = run_result.stdout.strip()
+        actual_stdout = run_result.stdout.replace("\r\n", "\n").strip()
         expected_stdout = (metadata.get("stdout") or "").strip()
-
-        actual_stderr = run_result.stderr.strip()
+        actual_stderr = run_result.stderr.replace("\r\n", "\n").strip()
         expected_stderr = (metadata.get("stderr") or "").strip()
         
         if actual_stdout != expected_stdout:


### PR DESCRIPTION
**Resolver Forward Reference Fix**

undefined type crash when declaring recursive anonymous structs (e.g., type XX = struct { value: XX* };). The resolve_typedef logic now eagerly injects a placeholder TypedefDeclID into the symbol table before parsing the right-hand side, allowing self-referential pointers to resolve successfully before the concrete type is finalized.

**LLVM Backend Regressions**

Solved an into_struct_value panic. When small structs (≤16 bytes) are optimized into scalar registers by the System V ABI, the compiler now dynamically spills the register into a stack slot (alloca) and uses a GEP instruction to safely extract fields.

Implemented a memory spill guard for ABI-coerced unions. Mutating or referencing a union now properly drops the raw integer into RAM first, providing the backend with a valid memory address (PointerValue).

Fixed a bug where recursive calls were reading stale registers. Mutation operators (like x++ and =) now force-sync their updated states back into the LocalIRValue registry, ensuring subsequent call frames load the fresh state.

**Cross-Platform Build & Test Infrastructure**

The Makefile now detects the host OS. It dynamically appends the .exe extension and uses the python command for Windows, while preserving suffix-less binaries and python3 for Linux.

Added the missing build dependency to the testsuite targets so the compiler compiles before the Python script attempts to run it.

Updated test_suite.py to scrub Windows carriage returns (\r\n to \n) from stdout and stderr captures, preventing false-positive string equality failures against our Unix-formatted test metadata.



**Graceful ASan Degradation**

Rewrote the build script for the Address Sanitizer wrapper. If the host is Windows or if llvm-config is missing from the system path, the script now gracefully catches the error instead of panicking.


