### PR TITLE
Add wrapper for void main function to return integer in abi lowering

### DIFF
--- a/crates/cyrusc_cir_lower/src/lib.rs
+++ b/crates/cyrusc_cir_lower/src/lib.rs
@@ -54,14 +54,15 @@ struct CIRLower<'a> {
     vtable_registry: Arc<VTableRegistry>,
     monomorph_registry: Arc<MonomorphRegistry>,
 
-    // TODO: Comment
     next_irv_id: IRValueID,
     decl_to_ir_value_map: FxHashMap<DeclID, IRValueID>,
     monomorph_to_ir_value_map: FxHashMap<MonomorphID, IRValueID>,
     vtable_to_ir_value_map: FxHashMap<VTableID, IRValueID>,
     func_decls: FxHashMap<IRValueID, CIRFuncDeclStmt>,
     global_var_decls: FxHashMap<IRValueID, CIRGlobalVarStmt>,
+    main_function: Option<CIRMainFunction>,
 }
+
 
 impl<'a> CIRLower<'a> {
     pub fn new(
@@ -91,6 +92,7 @@ impl<'a> CIRLower<'a> {
             func_decls: FxHashMap::new(),
             monomorph_to_ir_value_map: FxHashMap::new(),
             vtable_to_ir_value_map: FxHashMap::new(),
+            main_function: None
         }
     }
 
@@ -111,6 +113,7 @@ impl<'a> CIRLower<'a> {
             vtable_registry: self.vtable_registry.clone(),
             vtable_to_ir_value_map: self.vtable_to_ir_value_map.clone(),
             monomorph_to_ir_value_map: self.monomorph_to_ir_value_map.clone(),
+            main_function: self.main_function.clone(),
         }
     }
 
@@ -1151,6 +1154,14 @@ impl<'a> CIRLower<'a> {
         let body = self.lower_block(&func_def.body);
 
         let ret_type = self.lower_sema_type(&func_def.ret_type);
+
+        // ABI wrapper for void main function
+        if func_def.name == "main" {
+            self.main_function = Some(CIRMainFunction {
+                irv_id,
+                actual_ret_type: ret_type.clone(),
+            })
+        }
 
         if let Some(func_decl_id) = func_def.func_decl_id {
             self.decl_to_ir_value_map.insert(DeclID::Func(func_decl_id), irv_id);

--- a/crates/cyrusc_cli/src/commands.rs
+++ b/crates/cyrusc_cli/src/commands.rs
@@ -40,6 +40,8 @@ pub(crate) fn command_new(project_name: String, lib: bool) {
 }
 
 pub(crate) fn command_run(mut opts: CompilerOptions, file_path: Option<String>, program_args: Vec<String>) {
+    let start_time = std::time::Instant::now();
+
     let mut bundle = build_compilation_bundle(&mut opts, file_path);
 
     let ctx = Rc::new(create_compiler_context(
@@ -81,27 +83,37 @@ pub(crate) fn command_run(mut opts: CompilerOptions, file_path: Option<String>, 
         exit_with_msg!(err);
     }
 
+    let compile_duration = start_time.elapsed();
+    let compile_ms = compile_duration.as_millis();
+
     match Command::new(&temp_exe.path)
         .stdin(std::process::Stdio::inherit())
         .stdout(std::process::Stdio::inherit())
         .stderr(std::process::Stdio::inherit())
         .args(program_args)
-        .output()
+        .status()
     {
-        Ok(output) => {
-            io::stdout().write_all(&output.stdout).unwrap();
-            io::stderr().write_all(&output.stderr).unwrap();
+        Ok(status) => {
+            if !opts.quiet {
+                println!(
+                    "Program run with status code {}, took {} ms to compile.",
+                    status.code().unwrap_or(-1),
+                    compile_ms
+                );
+            }
         }
         Err(err) => {
-            eprintln!(
-                "failed to execute temporary program '{}': {err}",
+            exit_with_msg!(format!(
+                "Failed to execute program '{}': {err}",
                 temp_exe.path.display()
-            );
+            ));
         }
     }
 }
 
 pub(crate) fn command_build(mut opts: CompilerOptions, file_path: Option<String>, output_path_opt: Option<String>) {
+    let start_time = std::time::Instant::now();
+
     let mut bundle = build_compilation_bundle(&mut opts, file_path);
 
     let output_path_opt = output_path_opt.map(|path| Path::new(&path).to_path_buf());
@@ -138,6 +150,13 @@ pub(crate) fn command_build(mut opts: CompilerOptions, file_path: Option<String>
 
     if let Err(err) = ctx.trigger_linker(object_files, &output_path) {
         exit_with_msg!(err);
+    }
+
+    let compile_duration = start_time.elapsed();
+    let compile_ms = compile_duration.as_millis();
+
+    if !opts.quiet {
+        println!("Build completed, took {} ms to compile.", compile_ms);
     }
 }
 

--- a/crates/cyrusc_cli/src/main.rs
+++ b/crates/cyrusc_cli/src/main.rs
@@ -14,7 +14,7 @@ mod enums;
 mod options;
 mod scaffold;
 
-pub fn main() {
+fn main() {
     let args = Args::parse();
 
     dispatch(args);

--- a/crates/cyrusc_codegen_llvm/src/builder/builder.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/builder.rs
@@ -117,13 +117,14 @@ impl<'ll> CodeGenIRBuilder<'ll> {
             CIRStmt::Variable(var_stmt) => self.emit_var(var_stmt),
             CIRStmt::FuncDef(func_def_stmt) => {
                 let func_decl = cir_func_def_as_decl(func_def_stmt);
-                let cir_func_ty = cir_func_decl_as_func_type(&func_decl);
+                let cir_func_type = cir_func_decl_as_func_type(&func_decl);
                 let llvm_func_value = self.emit_func_decl(&func_decl);
+
                 self.set_current_func(llvm_func_value, func_def_stmt.abi_func_info.clone().unwrap());
 
                 let func_meta = {
                     if self.dctx.is_some() {
-                        Some(self.emit_func_meta(&cir_func_ty))
+                        Some(self.emit_func_meta(&cir_func_type))
                     } else {
                         None
                     }

--- a/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
@@ -772,8 +772,6 @@ impl<'ll> CodeGenIRBuilder<'ll> {
             && let Some(ir_value) = self.lookup_local_ir_value(cir_main.irv_id)
             && let Some(main_fn) = ir_value.as_func()
         {
-            let main_fn = main_fn;
-
             if *main_fn == cur_fn {
                 // emit implicit return zero
                 self.emit_implicit_return_zero();

--- a/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
@@ -30,7 +30,7 @@ use inkwell::{
         prelude::{LLVMBasicBlockRef, LLVMValueRef},
     },
     types::{BasicTypeEnum, StructType},
-    values::{AsValueRef, BasicValueEnum, FunctionValue, InstructionOpcode, IntValue},
+    values::{AsValueRef, BasicValue, BasicValueEnum, FunctionValue, InstructionOpcode, IntValue},
 };
 use inkwell::{
     llvm_sys::{
@@ -767,6 +767,20 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         let cur_abi_func_info = self.cur_abi_func_info.clone().unwrap();
         let ret_info = &cur_abi_func_info.ret_info;
 
+        // emit implicit return zero, if main function has void return type
+        if let Some(cir_main) = &self.cir_module.main_function
+            && let Some(ir_value) = self.lookup_local_ir_value(cir_main.irv_id)
+            && let Some(main_fn) = ir_value.as_func()
+        {
+            let main_fn = main_fn;
+
+            if *main_fn == cur_fn {
+                // emit implicit return zero
+                self.emit_implicit_return_zero();
+                return;
+            }
+        }
+
         match (&return_stmt.arg, &ret_info.kind) {
             (None, _) => {
                 self.emit_all_defers();
@@ -778,6 +792,7 @@ impl<'ll> CodeGenIRBuilder<'ll> {
 
                 self.llvmbuilder.build_return(None).unwrap();
             }
+
             (Some(expr), ABIRetInfoKind::Indirect { sret }) => {
                 let lvalue = self.emit_expr(expr, &Some(*ret_info.cir_ret_type.clone()));
                 let rvalue = self.load_rvalue(lvalue.clone());
@@ -817,6 +832,52 @@ impl<'ll> CodeGenIRBuilder<'ll> {
                 self.emit_all_defers();
                 self.llvmbuilder.build_return(Some(&return_value)).unwrap();
             }
+        }
+    }
+
+    fn emit_implicit_return_zero(&mut self) {
+        if let Some(cur_block) = &self.blockreg.cur_block {
+            self.llvmbuilder.position_at_end(*cur_block);
+            if cur_block.get_terminator().is_some() {
+                return;
+            }
+
+            let cir_ret_type = self.zero_return_type_for_void_main_function();
+            let llvm_ret_type: BasicTypeEnum<'ll> = self.emit_type(cir_ret_type).try_into().unwrap();
+
+            let zero_int = llvm_ret_type.const_zero();
+
+            self.llvmbuilder
+                .build_return(Some(&zero_int.as_basic_value_enum()))
+                .unwrap();
+        }
+    }
+
+    pub(crate) fn ensure_void_function_terminated(&mut self) {
+        let cur_fn = self.cur_func.unwrap();
+
+        if let Some(cir_main) = &self.cir_module.main_function
+            && let Some(ir_value) = self.lookup_local_ir_value(cir_main.irv_id)
+        {
+            let main_fn = ir_value.as_func().unwrap();
+
+            // detect ABI wrapped main function
+            // and emit implicit return zero instructionn
+            if *main_fn == cur_fn && cir_main.actual_ret_type.is_void() {
+                self.emit_all_defers();
+                self.emit_implicit_return_zero();
+                return;
+            }
+        }
+
+        if let Some(cur_block) = &self.blockreg.cur_block {
+            self.llvmbuilder.position_at_end(*cur_block);
+            if cur_block.get_terminator().is_some() {
+                return;
+            }
+
+            self.emit_all_defers();
+            self.llvmbuilder.build_return(None).unwrap();
         }
     }
 

--- a/crates/cyrusc_codegen_llvm/src/builder/exprs.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/exprs.rs
@@ -2175,14 +2175,17 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         if let Some(ptr) = sret_alloca {
             InternalValue::new(ret_type.clone(), InternalValueKind::LValue(ptr.into()))
         } else if let Some(mut basic_value) = call_site.try_as_basic_value().basic() {
-            // REVIEW: Optimization Required
-            // coerce back from abi return type to actual return type
             let actual_return_type: BasicTypeEnum<'ll> =
                 self.emit_type(*func_type.ret_type.clone()).try_into().unwrap();
 
-            basic_value = self.intrinsic_coerce_through_alloca(basic_value, actual_return_type, "coerce_ret");
+            // optimization, do not coerce if it matches actual return type
+            if actual_return_type == basic_value.get_type() {
+                InternalValue::new(ret_type.clone(), InternalValueKind::RValue(basic_value))
+            } else {
+                basic_value = self.intrinsic_coerce_through_alloca(basic_value, actual_return_type, "coerce_ret");
 
-            InternalValue::new(ret_type.clone(), InternalValueKind::RValue(basic_value))
+                InternalValue::new(ret_type.clone(), InternalValueKind::RValue(basic_value))
+            }
         } else {
             self.emit_null(ret_type.clone())
         }

--- a/crates/cyrusc_codegen_llvm/src/builder/funcs.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/funcs.rs
@@ -19,12 +19,13 @@ use cyrusc_ast::{
 };
 use cyrusc_internal::{
     abi::{
-        args::{ABIArgInfo, ABIArgKind, ABIFunctionInfo, ExpandKind},
+        args::{ABIArgInfo, ABIArgKind, ABIFunctionInfo, ABIRetInfoKind, ExpandKind},
         types::ABIType,
     },
     cir::{cir::*, types::*},
 };
 use cyrusc_source_loc::Loc;
+use cyrusc_typed_ast::types::PlainType;
 use inkwell::{
     context::AsContextRef,
     llvm_sys::{
@@ -34,7 +35,7 @@ use inkwell::{
         prelude::LLVMMetadataRef,
     },
     types::{AsTypeRef, BasicTypeEnum, StructType},
-    values::{AsValueRef, BasicMetadataValueEnum, BasicValueEnum, CallSiteValue, FunctionValue},
+    values::{AsValueRef, BasicMetadataValueEnum, BasicValue, BasicValueEnum, CallSiteValue, FunctionValue},
 };
 
 pub(crate) enum FuncCallKind<'ll> {
@@ -45,7 +46,13 @@ pub(crate) enum FuncCallKind<'ll> {
 // Declaration.
 impl<'ll> CodeGenIRBuilder<'ll> {
     pub(crate) fn emit_func_decl(&mut self, func_decl: &CIRFuncDeclStmt) -> FunctionValue<'ll> {
-        let cir_func_type = cir_func_decl_as_func_type(func_decl);
+        let mut cir_func_type = cir_func_decl_as_func_type(func_decl);
+
+        if let Some(cir_main) = &self.cir_module.main_function
+            && cir_main.irv_id == func_decl.irv_id
+        {
+            self.add_implicit_return_type_to_main_function(&mut cir_func_type);
+        }
 
         let llvm_func_type = self.emit_func_type(cir_func_type.clone());
 
@@ -308,28 +315,10 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         self.blockreg.labels.clear();
         self.emit_func_params(func_params.clone(), abi_func_info);
         self.emit_body(cir_block);
-        self.ensure_void_fn_terminated();
+        self.ensure_void_function_terminated();
 
         if let Some(dctx) = &mut self.dctx {
             dctx.func = parent_dctx_func.unwrap();
-        }
-    }
-
-    pub(crate) fn ensure_void_fn_terminated(&mut self) {
-        let cur_fn = self.cur_func.unwrap();
-
-        if cur_fn.get_type().get_return_type().is_some() {
-            return; // works only for void return type
-        }
-
-        if let Some(cur_block) = &self.blockreg.cur_block {
-            self.llvmbuilder.position_at_end(*cur_block);
-            if cur_block.get_terminator().is_some() {
-                return;
-            }
-
-            self.emit_all_defers();
-            self.llvmbuilder.build_return(None).unwrap();
         }
     }
 }
@@ -399,6 +388,42 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         let name = format!("lambda.{}", id);
         self.lambda_id += 1;
         name
+    }
+}
+
+// Main function.
+impl<'ll> CodeGenIRBuilder<'ll> {
+    fn add_implicit_return_type_to_main_function(&self, cir_func_type: &mut CIRFuncType) {
+        if !(cir_func_type.ret_type.is_integer() || cir_func_type.ret_type.is_void()) {
+            panic!("main function return type must be an integer or void");
+        }
+
+        if cir_func_type.ret_type.is_integer() {
+            return;
+        }
+
+        let cir_ret_type = self.zero_return_type_for_void_main_function();
+        let abi_ret_info = cir_func_type.abi_func_info.as_mut().unwrap();
+
+        let layout = self.tctx.layout_of(&cir_ret_type);
+        let int_width = layout.size * 8;
+
+        cir_func_type.ret_type = Box::new(cir_ret_type.clone());
+        abi_ret_info.ret_info.cir_ret_type = Box::new(cir_ret_type);
+        abi_ret_info.ret_info.abi_type = ABIType::Integer(int_width);
+        abi_ret_info.ret_info.kind = ABIRetInfoKind::Direct { coerce_to: None };
+    }
+
+    pub(crate) fn zero_return_type_for_void_main_function(&self) -> CIRType {
+        let int_bit_width = self.target.info.c_int_bit_width();
+
+        match int_bit_width {
+            16 => CIRType::Plain(PlainType::Int16),
+            32 => CIRType::Plain(PlainType::Int32),
+            64 => CIRType::Plain(PlainType::Int64),
+
+            _ => panic!("unsupported int size: {}", int_bit_width),
+        }
     }
 }
 

--- a/crates/cyrusc_codegen_llvm/src/lib.rs
+++ b/crates/cyrusc_codegen_llvm/src/lib.rs
@@ -128,8 +128,6 @@ impl CodeGenLLVM {
             optimize_module_with_custom_passes(&llvm_module, opt_level).unwrap();
         }
 
-        tui_compiled(cir_module.file_path.clone());
-
         if let Some(dctx) = &dctx {
             unsafe { finalize_debug(&dctx) };
             let llvm_module = owned_module.module.borrow();
@@ -139,6 +137,10 @@ impl CodeGenLLVM {
             if let Err(err) = llvm_module.verify() {
                 eprintln!("LLVM Module Error: {}", err)
             }
+        }
+
+        if !self.opts.quiet {
+            tui_compiled(cir_module.file_path.clone());
         }
     }
 

--- a/crates/cyrusc_compiler/src/context.rs
+++ b/crates/cyrusc_compiler/src/context.rs
@@ -94,7 +94,10 @@ impl CodeGenContext {
 
         self.save_cir_modules_source_hash_in_build_manifest(cir_modules);
 
-        tui_compile_finished();
+        if !self.opts.quiet {
+            tui_compile_finished();
+        }
+
         modules
     }
 

--- a/crates/cyrusc_internal/src/abi/target.rs
+++ b/crates/cyrusc_internal/src/abi/target.rs
@@ -139,6 +139,14 @@ impl ABITargetInfo {
         }
     }
 
+    /// Returns the bit width of C `int` for this target.
+    pub fn c_int_bit_width(&self) -> u32 {
+        match self.arch {
+            ABITargetArch::X86_64 | ABITargetArch::Aarch64 | ABITargetArch::RiscV64 => 32,
+            ABITargetArch::Wasm32 => 32,
+        }
+    }
+
     pub fn is_64bit(&self) -> bool {
         self.int_bit_width() == 64
     }

--- a/crates/cyrusc_internal/src/cir/cir.rs
+++ b/crates/cyrusc_internal/src/cir/cir.rs
@@ -17,6 +17,7 @@ use cyrusc_typed_ast::{
     LabelID, VTableID,
     builtins::TypedBuiltinSpec,
     decls::{MethodDecls, MonomorphID},
+    types::PlainType,
 };
 use fx_hash::FxHashMap;
 use std::{fmt::Debug, sync::Arc};
@@ -34,6 +35,13 @@ pub struct CIRModule {
     pub vtable_registry: Arc<VTableRegistry>,
     pub vtable_to_ir_value_map: FxHashMap<VTableID, IRValueID>,
     pub monomorph_to_ir_value_map: FxHashMap<MonomorphID, IRValueID>,
+    pub main_function: Option<CIRMainFunction>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CIRMainFunction {
+    pub irv_id: IRValueID,
+    pub actual_ret_type: CIRType,
 }
 
 #[derive(Debug, Clone)]
@@ -498,6 +506,20 @@ pub struct CIRGotoStmt {
 pub struct CIRDeferStmt {
     pub operand: Box<CIRStmt>,
     pub loc: Loc,
+}
+
+/// Creates a zero literal of the appropriate integer type for the target.
+pub fn cir_signed_int_literal(plain_type: PlainType, loc: Loc) -> CIRExpr {
+    let ty = CIRType::Plain(plain_type);
+
+    CIRExpr {
+        kind: CIRExprKind::Literal(CIRLiteral {
+            kind: CIRLiteralKind::Integer(IntLiteralKind::Signed(0), true),
+            ty: ty.clone(),
+        }),
+        ty,
+        loc,
+    }
 }
 
 #[inline]

--- a/crates/cyrusc_lexer/src/cli.rs
+++ b/crates/cyrusc_lexer/src/cli.rs
@@ -7,8 +7,7 @@ use cyrusc_lexer::Lexer;
 use cyrusc_source_loc::SourceMap;
 use std::{env, sync::Arc};
 
-// FIXME: Move to cyrusc_compiler/driver.rs
-pub fn main() {
+fn main() {
     let args: Vec<String> = env::args().collect();
     let file_path = args[1].clone();
     let (file_content, file_name) = read_file(file_path.clone());

--- a/crates/cyrusc_parser/src/cli.rs
+++ b/crates/cyrusc_parser/src/cli.rs
@@ -7,8 +7,7 @@ use cyrusc_parser::SourceParser;
 use cyrusc_source_loc::SourceMap;
 use std::{env, process::exit, sync::Arc};
 
-// FIXME: Move to cyrusc_compiler/driver.rs
-pub fn main() {
+fn main() {
     let args: Vec<String> = env::args().collect();
     let file_path = args[1].clone();
     let (file_content, file_name) = read_file(file_path.clone());

--- a/crates/cyrusc_resolver/src/cli.rs
+++ b/crates/cyrusc_resolver/src/cli.rs
@@ -14,7 +14,7 @@ use cyrusc_source_loc::SourceMap;
 use cyrusc_typed_ast::decls::table::DeclTablesRegistry;
 use std::{env, path::Path, process::exit, sync::Arc, vec};
 
-pub fn main() {
+fn main() {
     let args: Vec<String> = env::args().collect();
     let file_path = args[1].clone();
 
@@ -59,7 +59,13 @@ pub fn main() {
 
             let decl_tables = Arc::new(DeclTablesRegistry::new());
 
-            let mut resolver = Resolver::new(&opts, Box::new(fs_module_loader), source_map.clone(), reporter, decl_tables);
+            let mut resolver = Resolver::new(
+                &opts,
+                Box::new(fs_module_loader),
+                source_map.clone(),
+                reporter,
+                decl_tables,
+            );
 
             let module_symbol_id = resolver.create_entry_module_symbol_id(Path::new(&file_path), file_id);
 

--- a/crates/cyrusc_resolver/src/debugger_cli.rs
+++ b/crates/cyrusc_resolver/src/debugger_cli.rs
@@ -3,7 +3,10 @@
 
 use cyrusc_diagcentral::reporter::DiagReporter;
 use cyrusc_fs_utils::get_directory_of_file;
-use cyrusc_internal::{compiler_options::CompilerOptions, symbols::symbols::{SymbolEntry, SymbolEntryKind}};
+use cyrusc_internal::{
+    compiler_options::CompilerOptions,
+    symbols::symbols::{SymbolEntry, SymbolEntryKind},
+};
 use cyrusc_parser::SourceParser;
 use cyrusc_resolver::{
     Resolver,
@@ -23,7 +26,7 @@ use std::{
     vec,
 };
 
-pub fn main() {
+fn main() {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 3 {

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -91,7 +91,11 @@ def build_and_run(file_path, metadata, compiler_path, compiler_flags, output_dir
             text=True,
             env=env
         )
-
+        
+        # Check return status code first
+        if run_result.returncode != 0:
+            raise Exception(f"Test execution failed with exit code {run_result.returncode}:\n")
+            
         actual_stdout = run_result.stdout.replace("\r\n", "\n").strip()
         expected_stdout = (metadata.get("stdout") or "").strip()
         actual_stderr = run_result.stderr.replace("\r\n", "\n").strip()

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -91,10 +91,6 @@ def build_and_run(file_path, metadata, compiler_path, compiler_flags, output_dir
             text=True,
             env=env
         )
-        
-        # Check return status code first
-        if run_result.returncode != 0:
-            raise Exception(f"Test execution failed with exit code {run_result.returncode}:\n")
             
         actual_stdout = run_result.stdout.replace("\r\n", "\n").strip()
         expected_stdout = (metadata.get("stdout") or "").strip()
@@ -111,6 +107,9 @@ def build_and_run(file_path, metadata, compiler_path, compiler_flags, output_dir
                 f"Expected stderr:\n   {expected_stderr}\nGot stderr:\n   {actual_stderr}"
             )
 
+        # Check return status code first
+        if expected_stderr.strip() == "" and run_result.returncode != 0:
+            raise Exception(f"Test execution failed with exit code {run_result.returncode}:\n")
 
 def extract_test_metadata(content, file_name):
     metadata = {


### PR DESCRIPTION
Example:

```cyrus
pub fn main() { ... }
```

Lowers into:

```llvm
define i32 @main() !dbg !137 {
entry:
  ret i32 0, !dbg !140
}
```