### PR TITLE
Allocator

### DIFF
--- a/crates/cyrusc_codegen_llvm/src/llvm/debug_info.rs
+++ b/crates/cyrusc_codegen_llvm/src/llvm/debug_info.rs
@@ -606,6 +606,8 @@ pub unsafe fn debug_func_type(
 
     if let Some(ret) = ret_type {
         types.push(ret);
+    } else {
+        types.push(std::ptr::null_mut());
     }
 
     for p in params {

--- a/stdlib/fs/file.cyrus
+++ b/stdlib/fs/file.cyrus
@@ -19,4 +19,19 @@ pub struct File {
 	pub inline fn close(&self) int32 {
 		return fclose(self->handle);
 	}
+
+	pub inline fn read_all(&self, buffer: void*, size: usize, count: usize) usize {
+		return fread(buffer, size, count, self->handle);
+	}
+
+	pub inline fn write_all(&self, buffer: void*, size: usize, count: usize) usize {
+		return fwrite(buffer, size, count, self->handle);
+	}
+
+	pub inline fn size(&self) isize {
+		fseek(self->handle, 0, 2);
+		const sz = ftell(self->handle);
+		fseek(self->handle, 0, 0);
+		return sz;
+	}
 }

--- a/stdlib/fs/file.cyrus
+++ b/stdlib/fs/file.cyrus
@@ -1,0 +1,8 @@
+pub extern(c) {
+	fn fopen(filename: uint8*, mode: uint8*) void*;
+	fn fread(ptr: void*, size: usize, nmemb: usize, stream: void*) usize;
+	fn fwrite(ptr: void*, size: usize, nmemb: usize, stream: void*) usize;
+	fn fseek(stream: void*, offset: isize, whence: int32) int32;
+	fn ftell(stream: void*) isize;
+	fn fclose(stream: void*) int32;
+}

--- a/stdlib/fs/file.cyrus
+++ b/stdlib/fs/file.cyrus
@@ -1,5 +1,5 @@
 pub extern(c) {
-	fn fopen(filename: uint8*, mode: uint8*) void*;
+	fn fopen(filename: char*, mode: char*) void*;
 	fn fread(ptr: void*, size: usize, nmemb: usize, stream: void*) usize;
 	fn fwrite(ptr: void*, size: usize, nmemb: usize, stream: void*) usize;
 	fn fseek(stream: void*, offset: isize, whence: int32) int32;
@@ -8,5 +8,15 @@ pub extern(c) {
 }
 
 pub struct File {
-	handle: void*
+	handle: void*,
+
+	pub inline fn open(path: char*, mode: char*) Self {
+		return Self{
+			handle: fopen(path, mode)
+		};
+	}
+
+	pub inline fn close(&self) int32 {
+		return fclose(self->handle);
+	}
 }

--- a/stdlib/fs/file.cyrus
+++ b/stdlib/fs/file.cyrus
@@ -6,3 +6,7 @@ pub extern(c) {
 	fn ftell(stream: void*) isize;
 	fn fclose(stream: void*) int32;
 }
+
+pub struct File {
+	handle: void*
+}

--- a/stdlib/mem/allocator.cyrus
+++ b/stdlib/mem/allocator.cyrus
@@ -1,0 +1,72 @@
+import std::mem{
+	Allocator,
+	is_power_of_two,
+	align_up
+};
+
+pub struct BumpAllocator : Allocator {
+	ptr: void*,
+	cap: usize,
+	offset: usize,
+
+	pub inline fn new(ptr: void*, size: usize) Self {
+		return Self{
+			ptr: ptr,
+			cap: size,
+			offset: 0
+		};
+	}
+
+	pub inline fn alloc(&self, size: usize) void* {
+		const current = self->offset;
+		const next = current + size;
+
+		if (next > self->cap) {
+			return null;
+		}
+
+		const ptr = @cast(uintptr, self->ptr) + self->offset;
+		self->offset = next;
+
+		return @cast(void*, ptr);
+	}
+
+	pub inline fn alloc_aligned(&self, size: usize, align: usize) void* {
+		@assert(is_power_of_two(align));
+
+		const current = @cast(uintptr, self->ptr) + self->offset;
+		
+		const aligned = align_up(current, align);
+
+		const new_offset = (aligned - @cast(uintptr, self->ptr)) + size;
+
+		if (new_offset > self->cap) {
+			return null;
+		}
+
+		self->offset = new_offset;
+
+		return @cast(void*, aligned);
+	}
+
+	pub inline fn alloc_zeroed(&self, size: usize) void* {
+		const ptr = self->alloc(size);
+
+		if (ptr != null) {
+			@memset(ptr, 0, size);
+		}
+
+		return ptr;
+	}
+
+	pub inline fn realloc(&self, ptr: void*, size: usize) void* {
+		return null;
+	}
+
+	pub inline fn reset(&self) {
+		self->offset = 0;
+	}
+
+	pub inline fn free(&self, ptr: void*) {
+	}
+}


### PR DESCRIPTION
implemented the BumpAllocator

Scrapped the defective implementation and built a new native wrapper over libc (fopen, fread, etc.) for strict resource safety.

Found the -g module error