### PR TITLE
Implement Zero-Cost Compile-Time Reflection (#414) and Interface-Driven Error Handling (#415)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,7 @@ dependencies = [
  "cyrusc_internal",
  "cyrusc_scaffold_parser",
  "cyrusc_source_loc",
+ "cyrusc_tokens",
  "cyrusc_tui_utils",
  "cyrusc_typed_ast",
  "fx-hash",

--- a/crates/cyrusc_analyzer/src/monomorph.rs
+++ b/crates/cyrusc_analyzer/src/monomorph.rs
@@ -592,6 +592,9 @@ impl<'a> AnalysisContext<'a> {
             TypedExprKind::Dynamic(dynamic) => {
                 self.specialize_expr(&mut dynamic.operand, decl_map);
             }
+            TypedExprKind::Try(inner) => {
+                self.specialize_expr(inner, decl_map);
+            }
 
             TypedExprKind::Builtin(builtin) => match builtin {
                 TypedBuiltin::BuiltinFunc(builtin_func) => {

--- a/crates/cyrusc_analyzer/src/typecheck/exprs.rs
+++ b/crates/cyrusc_analyzer/src/typecheck/exprs.rs
@@ -121,6 +121,10 @@ impl<'a> AnalysisContext<'a> {
             TypedExprKind::ArrayIndex(array_index) => self.analyze_array_index(array_index),
             TypedExprKind::FieldAccess(field_access) => self.analyze_field_access(field_access),
             TypedExprKind::TupleAccess(tuple_access) => self.analyze_tuple_access(tuple_access, expected_type.clone()),
+            TypedExprKind::Try(inner) => {
+                self.analyze_expr(inner, None);
+                expr.ty.clone()
+            }
 
             TypedExprKind::Builtin(builtin) => match builtin {
                 TypedBuiltin::BuiltinFunc(builtin_func) => self.analyze_builtin_expr(builtin_func),
@@ -229,6 +233,7 @@ impl<'a> AnalysisContext<'a> {
             | TypedExprKind::Literal(_)
             | TypedExprKind::Unary(_)
             | TypedExprKind::Prefix(_)
+            | TypedExprKind::Try(_)
             | TypedExprKind::Infix(_) => ValueCategory::RValue,
 
             TypedExprKind::Builtin(_) => ValueCategory::RValue,

--- a/crates/cyrusc_ast/src/format.rs
+++ b/crates/cyrusc_ast/src/format.rs
@@ -424,6 +424,13 @@ impl fmt::Display for ASTExpr {
             }
             ASTExpr::UnnamedStructValue(unnamed_struct_value) => write!(f, "{}", unnamed_struct_value),
             ASTExpr::UnnamedUnionValue(unnamed_union_value) => write!(f, "{}", unnamed_union_value),
+            ASTExpr::Try(operand) => write!(f, "try {}", operand),
+            ASTExpr::Intrinsic(kind) => match kind {
+                IntrinsicKind::InfoOf(ty) => write!(f, "@info_of<{}>", ty),
+                IntrinsicKind::Type(args) => write!(f, "@type({})", format_expr_series(args)),
+                IntrinsicKind::Field(operand, field) => write!(f, "@field({}, {})", operand, field),
+                IntrinsicKind::CompileError(msg) => write!(f, "@compile_error({})", msg),
+            },
         }
     }
 }

--- a/crates/cyrusc_ast/src/lib.rs
+++ b/crates/cyrusc_ast/src/lib.rs
@@ -4,7 +4,7 @@
 use crate::abi::{ReprAttr, Visibility};
 use crate::modifiers::{EnumModifiers, FuncModifiers, GlobalVarModifiers, StructModifiers, UnionModifiers};
 use crate::operators::{InfixOperator, PrefixOperator, UnaryOperator};
-use cyrusc_source_loc::Loc;
+use cyrusc_source_loc::{Loc, FileID};
 use cyrusc_tokens::TokenKind;
 use cyrusc_tokens::{Token, literals::ASTLiteralExpr};
 use std::fmt;
@@ -1630,3 +1630,44 @@ impl Eq for GenericInst {}
 impl Eq for SelfType {}
 impl Eq for EnumVariantStructField {}
 impl Eq for EnumVariantTupleField {}
+
+impl ASTExpr {
+    pub fn loc(&self) -> Loc {
+        match self {
+            ASTExpr::Ident(ident) => ident.loc,
+            ASTExpr::TypeSpecifier(type_spec) => type_spec.loc(),
+            ASTExpr::ModuleImport(module_import) => module_import.loc,
+            ASTExpr::Builtin(builtin) => builtin.loc(),
+            ASTExpr::Assign(assign) => assign.loc,
+            ASTExpr::Literal(literal) => literal.loc,
+            ASTExpr::Prefix(prefix) => prefix.loc,
+            ASTExpr::Infix(infix) => infix.loc,
+            ASTExpr::Unary(unary) => unary.loc,
+            ASTExpr::Array(array) => array.loc,
+            ASTExpr::UntypedArray(untyped_array) => untyped_array.loc,
+            ASTExpr::ArrayIndex(array_index) => array_index.loc,
+            ASTExpr::AddrOf(addr_of) => addr_of.loc,
+            ASTExpr::Deref(deref) => deref.loc,
+            ASTExpr::StructInit(struct_init) => struct_init.loc,
+            ASTExpr::FuncCall(func_call) => func_call.loc,
+            ASTExpr::FieldAccess(field_access) => field_access.loc,
+            ASTExpr::MethodCall(method_call) => method_call.loc,
+            ASTExpr::Lambda(lambda) => lambda.loc,
+            ASTExpr::Tuple(tuple) => tuple.loc,
+            ASTExpr::TupleAccess(tuple_access) => tuple_access.loc,
+            ASTExpr::Dynamic(dynamic) => dynamic.loc,
+            ASTExpr::EnumStructVariantInit(enum_struct_variant_init) => enum_struct_variant_init.loc,
+            ASTExpr::UnnamedStructValue(unnamed_struct_value) => unnamed_struct_value.loc,
+            ASTExpr::UnnamedUnionValue(unnamed_union_value) => unnamed_union_value.loc,
+            ASTExpr::UnnamedEnumValue(unnamed_enum_value) => unnamed_enum_value.loc,
+            ASTExpr::Try(expr) => expr.loc(),
+            ASTExpr::Intrinsic(intrinsic) => match intrinsic {
+                IntrinsicKind::InfoOf(type_spec) => type_spec.loc(),
+                IntrinsicKind::Type(args) => args.first().map(|e| e.loc()).unwrap_or_else(|| Loc::default(FileID(0))),
+                IntrinsicKind::Field(expr, _ident) => expr.loc(),
+                IntrinsicKind::CompileError(expr) => expr.loc(),
+            },
+        }
+    }
+}
+

--- a/crates/cyrusc_ast/src/lib.rs
+++ b/crates/cyrusc_ast/src/lib.rs
@@ -24,6 +24,14 @@ pub struct ProgramTree {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IntrinsicKind {
+    InfoOf(TypeSpecifier),
+    Type(Vec<ASTExpr>),
+    Field(Box<ASTExpr>, Ident),
+    CompileError(Box<ASTExpr>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ASTExpr {
     Ident(Ident),
     TypeSpecifier(TypeSpecifier),
@@ -51,6 +59,8 @@ pub enum ASTExpr {
     UnnamedStructValue(ASTUnnamedStructValueExpr),
     UnnamedUnionValue(ASTUnnamedUnionValueExpr),
     UnnamedEnumValue(ASTUnnamedEnumValueExpr),
+    Try(Box<ASTExpr>),
+    Intrinsic(IntrinsicKind),
 }
 
 #[derive(Debug, Clone)]
@@ -695,6 +705,7 @@ pub struct ASTFuncDeclStmt {
     pub ret_type: Option<TypeSpecifier>,
     pub modifiers: FuncModifiers,
     pub renamed_as: Option<Ident>,
+    pub is_comptime: bool,
     pub loc: Loc,
 }
 
@@ -985,6 +996,7 @@ impl ASTFuncDefStmt {
             ret_type: self.ret_type.clone(),
             modifiers: self.modifiers.clone(),
             renamed_as: None,
+            is_comptime: false,
             loc: self.loc,
         }
     }

--- a/crates/cyrusc_cir_dump/src/lib.rs
+++ b/crates/cyrusc_cir_dump/src/lib.rs
@@ -538,6 +538,7 @@ impl<'a> CIRPrinter<'a> {
             }
 
             CIRExprKind::Type(ty) => self.print_type(ty),
+            CIRExprKind::Try(inner) => format!("try {}", self.print_expr(inner)),
         }
     }
 

--- a/crates/cyrusc_cir_lower/src/lib.rs
+++ b/crates/cyrusc_cir_lower/src/lib.rs
@@ -1565,6 +1565,7 @@ impl<'a> CIRLower<'a> {
             TypedExprKind::StructInit(struct_init) => self.lower_struct_init(struct_init),
             TypedExprKind::UnionInit(union_init) => self.lower_union_init(union_init),
             TypedExprKind::EnumInit(enum_init) => self.lower_enum_init(enum_init),
+            TypedExprKind::Try(inner) => CIRExprKind::Try(Box::new(self.lower_expr(inner))),
 
             TypedExprKind::Builtin(builtin) => {
                 let stmt = self.lower_builtin(builtin).first().cloned().unwrap();

--- a/crates/cyrusc_codegen_llvm/Cargo.toml
+++ b/crates/cyrusc_codegen_llvm/Cargo.toml
@@ -9,6 +9,7 @@ cyrusc_source_loc = { path = "../cyrusc_source_loc", version = "*" }
 cyrusc_typed_ast = { path = "../cyrusc_typed_ast", version = "*" }
 cyrusc_buildmanifest = { path = "../cyrusc_buildmanifest", version = "*" }
 cyrusc_ast = { path = "../cyrusc_ast", version = "*" }
+cyrusc_tokens = { path = "../cyrusc_tokens", version = "*" }
 cyrusc_compiler = { path = "../cyrusc_compiler", version = "*" }
 cyrusc_internal = { path = "../cyrusc_internal", version = "*" }
 cyrusc_diagcentral = { path = "../cyrusc_diagcentral", version = "*" }

--- a/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
@@ -832,6 +832,46 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         }
     }
 
+    pub(crate) fn emit_return_value(&mut self, err_val: InternalValue<'ll>) {
+        let cur_fn = self.cur_func.unwrap();
+        let cur_abi_func_info = self.cur_abi_func_info.clone().unwrap();
+        let ret_info = &cur_abi_func_info.ret_info;
+
+        match &ret_info.kind {
+            ABIRetInfoKind::Ignore => {
+                self.emit_all_defers();
+                self.llvmbuilder.build_return(None).unwrap();
+            }
+            ABIRetInfoKind::Indirect { sret } => {
+                let rvalue = self.load_rvalue(err_val.clone());
+                if *sret {
+                    self.emit_compute_indirect_sret(cur_fn, &err_val, &rvalue);
+                    self.emit_all_defers();
+                    self.llvmbuilder.build_return(None).unwrap();
+                }
+            }
+            ABIRetInfoKind::Direct { coerce_to } => {
+                let rvalue = self.load_rvalue(err_val);
+                let ret_ty = abi_type_to_llvm_type(self.llvm_ctx, &self.target.info, &ret_info.abi_type);
+                let value: BasicValueEnum<'ll> = if let Some(coerce) = coerce_to {
+                    let coerce_ty = abi_type_to_llvm_type(self.llvm_ctx, &self.target.info, coerce);
+                    self.emit_cast(coerce_ty, rvalue).try_into().unwrap()
+                } else {
+                    self.emit_cast(ret_ty, rvalue).try_into().unwrap()
+                };
+                let return_value = self.intrinsic_coerce_through_alloca(value, ret_ty.try_into().unwrap(), "coerce.ret");
+                self.emit_all_defers();
+                self.llvmbuilder.build_return(Some(&return_value)).unwrap();
+            }
+            ABIRetInfoKind::DirectPair { lo, hi } => {
+                let rvalue = self.load_rvalue(err_val);
+                let return_value = self.emit_compute_return_direct_pair(rvalue, lo, hi, &ret_info.abi_type);
+                self.emit_all_defers();
+                self.llvmbuilder.build_return(Some(&return_value)).unwrap();
+            }
+        }
+    }
+
     fn emit_implicit_return_zero(&mut self) {
         if let Some(cur_block) = &self.blockreg.cur_block {
             self.llvmbuilder.position_at_end(*cur_block);

--- a/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
@@ -10,6 +10,8 @@ use crate::{
     c,
     llvm::abi::abi_type::abi_type_to_llvm_type,
 };
+use cyrusc_ast::operators::{InfixOperator, PrefixOperator};
+use cyrusc_tokens::literals::IntLiteralKind;
 use cyrusc_internal::{
     abi::{args::ABIRetInfoKind, layout::ABITypeLayout, types::ABIType},
     cir::{
@@ -470,6 +472,103 @@ impl<'ll> CodeGenIRBuilder<'ll> {
 // Loops.
 impl<'ll> CodeGenIRBuilder<'ll> {
     pub(crate) fn emit_for(&mut self, for_stmt: &CIRForStmt) {
+        if let Some((start, end, step, var_id)) = try_get_loop_bounds(for_stmt) {
+            let mut val = start;
+            let mut iterations = Vec::new();
+            let op = match &for_stmt.cond.as_ref().unwrap().kind {
+                CIRExprKind::Infix(infix) => infix.op,
+                _ => unreachable!(),
+            };
+            let check_cond = |i: i64| -> bool {
+                match op {
+                    InfixOperator::Less => i < end,
+                    InfixOperator::LessEqual => i <= end,
+                    InfixOperator::Greater => i > end,
+                    InfixOperator::GreaterEqual => i >= end,
+                    InfixOperator::NotEqual => i != end,
+                    _ => false,
+                }
+            };
+            while check_cond(val) {
+                iterations.push(val);
+                val += step;
+                if iterations.len() > 1000 {
+                    break;
+                }
+            }
+
+            if let Some(initializer) = &for_stmt.initializer {
+                self.emit_var(initializer);
+            }
+
+            let loop_var_ptr = match self.lookup_local_ir_value(var_id).unwrap() {
+                LocalIRValue::LValue(ptr, _) => ptr,
+                _ => panic!("Expected loop variable to be an LValue"),
+            };
+            let val_type = for_stmt.initializer.as_ref().unwrap().ty.clone();
+            let llvm_val_type: BasicTypeEnum<'ll> = self.emit_type(val_type.clone()).try_into().unwrap();
+
+            let exit_block = self.new_basic_block("for.unrolled.exit");
+            let mut body_blocks = Vec::new();
+            for i in 0..iterations.len() {
+                body_blocks.push(self.new_basic_block(&format!("for.unrolled.body.{}", i)));
+            }
+
+            let first_block = body_blocks.first().copied().unwrap_or(exit_block);
+            let cur_block = self.blockreg.cur_block.unwrap();
+            self.emit_block(cur_block);
+            if cur_block.get_terminator().is_none() {
+                self.llvmbuilder.build_unconditional_branch(first_block).unwrap();
+            }
+
+            let loop_defer_depth = self.defer_stack.len();
+
+            for (k, &iteration_val) in iterations.iter().enumerate() {
+                let current_body_bb = body_blocks[k];
+                let next_body_bb = if k + 1 < body_blocks.len() {
+                    body_blocks[k + 1]
+                } else {
+                    exit_block
+                };
+
+                self.blockreg.control_flow_stack.push(ControlRegion::Loop(LoopControlRegion::new(
+                    Some(next_body_bb),
+                    None,
+                    exit_block,
+                    loop_defer_depth,
+                )));
+
+                self.emit_block(current_body_bb);
+
+                let const_val = llvm_val_type.into_int_type().const_int(iteration_val as u64, false);
+                self.emit_store(
+                    loop_var_ptr,
+                    InternalValue::new(val_type.clone(), InternalValueKind::RValue(const_val.into())),
+                    val_type.clone(),
+                );
+
+                self.emit_body(&for_stmt.body);
+
+                if let Some(cur_bb) = &self.blockreg.cur_block {
+                    if cur_bb.get_terminator().is_none() {
+                        self.llvmbuilder.build_unconditional_branch(next_body_bb).unwrap();
+                    }
+                }
+
+                self.blockreg.control_flow_stack.pop();
+            }
+
+            let exit_in_use: bool = unsafe {
+                let first_use: *const LLVMUse = LLVMGetFirstUse(LLVMBasicBlockAsValue(exit_block.as_mut_ptr()));
+                !first_use.is_null()
+            };
+            if exit_in_use || iterations.is_empty() {
+                self.emit_block(exit_block);
+            }
+
+            return;
+        }
+
         let cond_block = for_stmt.cond.as_ref().map(|_| self.new_basic_block("for.cond"));
         let inc_block = for_stmt.increment.as_ref().map(|_| self.new_basic_block("for_inc"));
         let body_block = self.new_basic_block("for.body");
@@ -531,7 +630,7 @@ impl<'ll> CodeGenIRBuilder<'ll> {
                 if for_stmt.cond.is_some() {
                     next_block = inc_block.or(cond_block).unwrap_or(exit_block);
                 } else {
-                    next_block = body_block; // unconditional for loop
+                    next_block = body_block;
                 }
 
                 self.llvmbuilder.build_unconditional_branch(next_block).unwrap();
@@ -1146,4 +1245,82 @@ impl<'ll> CodeGenIRBuilder<'ll> {
             BasicBlock::new(llvm_bb).unwrap()
         }
     }
+}
+
+fn get_const_int(expr: &CIRExpr) -> Option<i64> {
+    match &expr.kind {
+        CIRExprKind::Literal(lit) => match &lit.kind {
+            CIRLiteralKind::Integer(IntLiteralKind::Signed(val), _) => Some(*val as i64),
+            CIRLiteralKind::Integer(IntLiteralKind::Unsigned(val), _) => Some(*val as i64),
+            _ => None,
+        }
+        _ => None,
+    }
+}
+
+fn try_get_loop_bounds(for_stmt: &CIRForStmt) -> Option<(i64, i64, i64, IRValueID)> {
+    let initializer = for_stmt.initializer.as_ref()?;
+    let var_id = initializer.irv_id;
+    let start = get_const_int(initializer.expr.as_ref()?)?;
+
+    let cond = for_stmt.cond.as_ref()?;
+    let (end, op) = match &cond.kind {
+        CIRExprKind::Infix(infix) => {
+            let end_val = get_const_int(&infix.rhs)?;
+            (end_val, infix.op)
+        }
+        _ => return None,
+    };
+
+    let step = match &for_stmt.increment.as_ref()?.kind {
+        CIRExprKind::Assign(assign) => {
+            match &assign.rhs.kind {
+                CIRExprKind::Infix(infix) => {
+                    if infix.op == InfixOperator::Plus {
+                        get_const_int(&infix.rhs)?
+                    } else if infix.op == InfixOperator::Minus {
+                        -get_const_int(&infix.rhs)?
+                    } else {
+                        return None;
+                    }
+                }
+                _ => return None,
+            }
+        }
+        CIRExprKind::Prefix(prefix) => {
+            if prefix.op == PrefixOperator::PlusPlus {
+                1
+            } else if prefix.op == PrefixOperator::MinusMinus {
+                -1
+            } else {
+                return None;
+            }
+        }
+        _ => return None,
+    };
+
+    let check_cond = |i: i64| -> bool {
+        match op {
+            InfixOperator::Less => i < end,
+            InfixOperator::LessEqual => i <= end,
+            InfixOperator::Greater => i > end,
+            InfixOperator::GreaterEqual => i >= end,
+            InfixOperator::NotEqual => i != end,
+            _ => false,
+        }
+    };
+
+    if !check_cond(start) {
+        return Some((start, start, step, var_id));
+    }
+    if step == 0 {
+        return None;
+    }
+    if step > 0 && start < end {
+    } else if step < 0 && start > end {
+    } else {
+        return None;
+    }
+
+    Some((start, end, step, var_id))
 }

--- a/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/control_flow.rs
@@ -10,7 +10,7 @@ use crate::{
     c,
     llvm::abi::abi_type::abi_type_to_llvm_type,
 };
-use cyrusc_ast::operators::{InfixOperator, PrefixOperator};
+use cyrusc_ast::operators::{InfixOperator, PrefixOperator, UnaryOperator};
 use cyrusc_tokens::literals::IntLiteralKind;
 use cyrusc_internal::{
     abi::{args::ABIRetInfoKind, layout::ABITypeLayout, types::ABIType},
@@ -18,6 +18,7 @@ use cyrusc_internal::{
         cir::{
             CIRBlockStmt, CIRBreakStmt, CIRContinueStmt, CIRForStmt, CIRGotoStmt, CIRIfStmt, CIRLabelStmt, CIRPattern,
             CIRReturnStmt, CIRStmt, CIRSwitchStmt, CIRVariantPayload, CIRWhileStmt, IRValueID,
+            CIRExpr, CIRExprKind, CIRLiteral, CIRLiteralKind,
         },
         types::CIRType,
     },
@@ -481,9 +482,9 @@ impl<'ll> CodeGenIRBuilder<'ll> {
             };
             let check_cond = |i: i64| -> bool {
                 match op {
-                    InfixOperator::Less => i < end,
+                    InfixOperator::LessThan => i < end,
                     InfixOperator::LessEqual => i <= end,
-                    InfixOperator::Greater => i > end,
+                    InfixOperator::GreaterThan => i > end,
                     InfixOperator::GreaterEqual => i >= end,
                     InfixOperator::NotEqual => i != end,
                     _ => false,
@@ -1276,9 +1277,9 @@ fn try_get_loop_bounds(for_stmt: &CIRForStmt) -> Option<(i64, i64, i64, IRValueI
         CIRExprKind::Assign(assign) => {
             match &assign.rhs.kind {
                 CIRExprKind::Infix(infix) => {
-                    if infix.op == InfixOperator::Plus {
+                    if infix.op == InfixOperator::Add {
                         get_const_int(&infix.rhs)?
-                    } else if infix.op == InfixOperator::Minus {
+                    } else if infix.op == InfixOperator::Sub {
                         -get_const_int(&infix.rhs)?
                     } else {
                         return None;
@@ -1287,10 +1288,10 @@ fn try_get_loop_bounds(for_stmt: &CIRForStmt) -> Option<(i64, i64, i64, IRValueI
                 _ => return None,
             }
         }
-        CIRExprKind::Prefix(prefix) => {
-            if prefix.op == PrefixOperator::PlusPlus {
+        CIRExprKind::Unary(unary) => {
+            if unary.op == UnaryOperator::PreIncrement || unary.op == UnaryOperator::PostIncrement {
                 1
-            } else if prefix.op == PrefixOperator::MinusMinus {
+            } else if unary.op == UnaryOperator::PreDecrement || unary.op == UnaryOperator::PostDecrement {
                 -1
             } else {
                 return None;
@@ -1301,9 +1302,9 @@ fn try_get_loop_bounds(for_stmt: &CIRForStmt) -> Option<(i64, i64, i64, IRValueI
 
     let check_cond = |i: i64| -> bool {
         match op {
-            InfixOperator::Less => i < end,
+            InfixOperator::LessThan => i < end,
             InfixOperator::LessEqual => i <= end,
-            InfixOperator::Greater => i > end,
+            InfixOperator::GreaterThan => i > end,
             InfixOperator::GreaterEqual => i >= end,
             InfixOperator::NotEqual => i != end,
             _ => false,

--- a/crates/cyrusc_codegen_llvm/src/builder/exprs.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/exprs.rs
@@ -63,6 +63,7 @@ impl<'ll> CodeGenIRBuilder<'ll> {
             CIRExprKind::Call(call) => self.emit_call(call),
             CIRExprKind::Lambda(lambda) => self.emit_lambda(lambda),
             CIRExprKind::Dynamic(dynamic) => self.emit_dynamic_expr(dynamic),
+            CIRExprKind::Try(inner) => self.emit_try(inner),
 
             CIRExprKind::Type(_) => unreachable!(),
         };
@@ -2375,6 +2376,138 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         };
 
         InternalValue::new(lit.ty.clone(), InternalValueKind::RValue(basic_value))
+    }
+
+    fn emit_try(&mut self, inner_expr: &CIRExpr) -> InternalValue<'ll> {
+        let cur_fn = self.cur_func.unwrap();
+
+        let object_name = match &inner_expr.ty {
+            CIRType::Struct(type_id) => {
+                let struct_type = self.tctx.get_struct(*type_id);
+                struct_type.name.clone().unwrap_or_default()
+            }
+            CIRType::Enum(type_id) => {
+                let enum_type = self.tctx.get_enum(*type_id);
+                enum_type.name.clone().unwrap_or_default()
+            }
+            CIRType::Union(type_id) => {
+                let union_type = self.tctx.get_union(*type_id);
+                union_type.name.clone().unwrap_or_default()
+            }
+            _ => panic!("Expected a struct, enum, or union for Try operand"),
+        };
+
+        let mut is_error_info = None;
+        let mut extract_error_info = None;
+        let mut extract_value_info = None;
+
+        for (&irv_id, func_decl) in &self.cir_module.func_decls {
+            let name = &func_decl.name;
+            if let Some(dot_idx) = name.rfind('.') {
+                let struct_part = &name[..dot_idx];
+                let method_part = &name[dot_idx + 1..];
+                if struct_part == object_name || struct_part.ends_with(&format!("${}", object_name)) {
+                    if method_part == "is_error" {
+                        is_error_info = Some((irv_id, func_decl.clone()));
+                    } else if method_part == "extract_error" {
+                        extract_error_info = Some((irv_id, func_decl.clone()));
+                    } else if method_part == "extract_value" {
+                        extract_value_info = Some((irv_id, func_decl.clone()));
+                    }
+                }
+            }
+            if let Some(double_underscore_idx) = name.rfind("__") {
+                let struct_part = &name[..double_underscore_idx];
+                let method_part = &name[double_underscore_idx + 2..];
+                if struct_part == object_name || struct_part.ends_with(&format!("_{}", object_name)) {
+                    if method_part == "is_error" {
+                        is_error_info = Some((irv_id, func_decl.clone()));
+                    } else if method_part == "extract_error" {
+                        extract_error_info = Some((irv_id, func_decl.clone()));
+                    } else if method_part == "extract_value" {
+                        extract_value_info = Some((irv_id, func_decl.clone()));
+                    }
+                }
+            }
+        }
+
+        if is_error_info.is_none() {
+            for (&irv_id, func_decl) in &self.cir_module.func_decls {
+                let name = &func_decl.name;
+                if name.contains(&object_name) {
+                    if name.ends_with("is_error") {
+                        is_error_info = Some((irv_id, func_decl.clone()));
+                    } else if name.ends_with("extract_error") {
+                        extract_error_info = Some((irv_id, func_decl.clone()));
+                    } else if name.ends_with("extract_value") {
+                        extract_value_info = Some((irv_id, func_decl.clone()));
+                    }
+                }
+            }
+        }
+
+        let (is_error_id, is_error_decl) = is_error_info.expect("is_error method not found");
+        let (extract_error_id, extract_error_decl) = extract_error_info.expect("extract_error method not found");
+        let (extract_value_id, extract_value_decl) = extract_value_info.expect("extract_value method not found");
+
+        let is_error_func_type = cir_func_decl_as_func_type(&is_error_decl);
+        let extract_error_func_type = cir_func_decl_as_func_type(&extract_error_decl);
+        let extract_value_func_type = cir_func_decl_as_func_type(&extract_value_decl);
+
+        let mut call_method = |builder: &mut Self, irv_id: IRValueID, func_type: CIRFuncType, ret_type: CIRType, name: String| {
+            let is_referenced = func_type.params.first().map_or(false, |ty| ty.is_pointer());
+            builder.emit_call(&CIRCall {
+                args: vec![],
+                ret_type,
+                dispatch: CIRCallDispatch::Method {
+                    irv_id,
+                    func_type,
+                    abi_name: name,
+                    self_meta: Some(CIRCallMethodSelfMetadata {
+                        operand: Box::new(inner_expr.clone()),
+                        use_fat_ptr_data: false,
+                        is_referenced,
+                    }),
+                },
+                loc: inner_expr.loc,
+            })
+        };
+
+        let is_error_res = call_method(
+            self,
+            is_error_id,
+            is_error_func_type,
+            is_error_decl.ret_type.clone(),
+            is_error_decl.name.clone()
+        );
+
+        let is_error_bool = self.load_rvalue(is_error_res).as_basic_value().into_int_value();
+
+        let early_return_block = self.llvm_ctx.append_basic_block(cur_fn, "try.early_return");
+        let cont_block = self.llvm_ctx.append_basic_block(cur_fn, "try.cont");
+
+        self.llvmbuilder.build_conditional_branch(is_error_bool, early_return_block, cont_block).unwrap();
+
+        self.emit_block(early_return_block);
+        let error_val = call_method(
+            self,
+            extract_error_id,
+            extract_error_func_type,
+            extract_error_decl.ret_type.clone(),
+            extract_error_decl.name.clone()
+        );
+        self.emit_return_value(error_val);
+
+        self.emit_block(cont_block);
+        let success_val = call_method(
+            self,
+            extract_value_id,
+            extract_value_func_type,
+            extract_value_decl.ret_type.clone(),
+            extract_value_decl.name.clone()
+        );
+
+        success_val
     }
 
     pub(crate) fn emit_null(&self, ty: CIRType) -> InternalValue<'ll> {

--- a/crates/cyrusc_codegen_llvm/src/builder/exprs.rs
+++ b/crates/cyrusc_codegen_llvm/src/builder/exprs.rs
@@ -2454,7 +2454,7 @@ impl<'ll> CodeGenIRBuilder<'ll> {
         let extract_error_func_type = cir_func_decl_as_func_type(&extract_error_decl);
         let extract_value_func_type = cir_func_decl_as_func_type(&extract_value_decl);
 
-        let mut call_method = |builder: &mut Self, irv_id: IRValueID, func_type: CIRFuncType, ret_type: CIRType, name: String| {
+        let call_method = |builder: &mut Self, irv_id: IRValueID, func_type: CIRFuncType, ret_type: CIRType, name: String| {
             let is_referenced = func_type.params.first().map_or(false, |ty| ty.is_pointer());
             builder.emit_call(&CIRCall {
                 args: vec![],

--- a/crates/cyrusc_const_eval/src/value.rs
+++ b/crates/cyrusc_const_eval/src/value.rs
@@ -99,6 +99,7 @@ pub fn is_expr_const_evaluable(expr: &TypedExprKind) -> bool {
         | TypedExprKind::FuncCall(_)
         | TypedExprKind::Assign(_)
         | TypedExprKind::Dynamic(_)
+        | TypedExprKind::Try(_)
         | TypedExprKind::AddrOf(_) => false,
 
         // IMPORTANT:

--- a/crates/cyrusc_internal/src/cir/cir.rs
+++ b/crates/cyrusc_internal/src/cir/cir.rs
@@ -95,6 +95,7 @@ pub enum CIRExprKind {
     Dynamic(CIRDynamicExpr),
     Call(CIRCall),
     Type(CIRType),
+    Try(Box<CIRExpr>),
 }
 
 #[derive(Debug, Clone)]

--- a/crates/cyrusc_lexer/src/lib.rs
+++ b/crates/cyrusc_lexer/src/lib.rs
@@ -175,7 +175,7 @@ impl<'source_map, 'source_file> Lexer<'source_map, 'source_file> {
 
             ',' => self.single(TokenKind::Comma),
             ';' => self.single(TokenKind::Semicolon),
-            '@' => self.single(TokenKind::At),
+            '@' => return self.read_at_intrinsic(),
 
             _ => self.invalid_char(),
         }
@@ -193,6 +193,28 @@ impl<'source_map, 'source_file> Lexer<'source_map, 'source_file> {
         }
 
         self.read_ident()
+    }
+
+    fn read_at_intrinsic(&mut self) -> TokenKind {
+        self.read_char(); // consume '@'
+
+        if !self.ch.is_alphabetic() && self.ch != '_' {
+            return TokenKind::At;
+        }
+
+        let mut name = String::new();
+        while self.ch.is_alphanumeric() || self.ch == '_' {
+            name.push(self.ch);
+            self.read_char();
+        }
+
+        match name.as_str() {
+            "info_of" => TokenKind::IntrinsicInfoOf,
+            "type" => TokenKind::IntrinsicType,
+            "field" => TokenKind::IntrinsicField,
+            "compile_error" => TokenKind::IntrinsicCompileError,
+            _ => TokenKind::At,
+        }
     }
 
     fn read_colon(&mut self) -> TokenKind {
@@ -769,6 +791,8 @@ fn lookup_identifier(ident: String) -> TokenKind {
         "false" => TokenKind::False,
         "null" => TokenKind::Null,
         "as" => TokenKind::As,
+        "comptime" => TokenKind::Comptime,
+        "try" => TokenKind::Try,
         "in" => TokenKind::In,
         "enum" => TokenKind::Enum,
         "void" => TokenKind::Void,

--- a/crates/cyrusc_lexer/src/lib.rs
+++ b/crates/cyrusc_lexer/src/lib.rs
@@ -202,6 +202,12 @@ impl<'source_map, 'source_file> Lexer<'source_map, 'source_file> {
             return TokenKind::At;
         }
 
+        let saved_pos = self.pos;
+        let saved_next_pos = self.next_pos;
+        let saved_ch = self.ch;
+        let saved_line = self.line;
+        let saved_column = self.column;
+
         let mut name = String::new();
         while self.ch.is_alphanumeric() || self.ch == '_' {
             name.push(self.ch);
@@ -213,7 +219,14 @@ impl<'source_map, 'source_file> Lexer<'source_map, 'source_file> {
             "type" => TokenKind::IntrinsicType,
             "field" => TokenKind::IntrinsicField,
             "compile_error" => TokenKind::IntrinsicCompileError,
-            _ => TokenKind::At,
+            _ => {
+                self.pos = saved_pos;
+                self.next_pos = saved_next_pos;
+                self.ch = saved_ch;
+                self.line = saved_line;
+                self.column = saved_column;
+                TokenKind::At
+            }
         }
     }
 

--- a/crates/cyrusc_parser/src/exprs.rs
+++ b/crates/cyrusc_parser/src/exprs.rs
@@ -1449,7 +1449,12 @@ fn can_start_expr(kind: &TokenKind) -> bool {
         | TokenKind::LeftParen
         | TokenKind::LeftBrace
         | TokenKind::Increment
-        | TokenKind::Decrement => true,
+        | TokenKind::Decrement
+        | TokenKind::Try
+        | TokenKind::IntrinsicInfoOf
+        | TokenKind::IntrinsicType
+        | TokenKind::IntrinsicField
+        | TokenKind::IntrinsicCompileError => true,
 
         TokenKind::Undefined
         | TokenKind::Static
@@ -1507,6 +1512,7 @@ fn can_start_expr(kind: &TokenKind) -> bool {
         | TokenKind::In
         | TokenKind::Enum
         | TokenKind::As
+        | TokenKind::Comptime
         | TokenKind::UIntPtr
         | TokenKind::IntPtr
         | TokenKind::ISize

--- a/crates/cyrusc_parser/src/exprs.rs
+++ b/crates/cyrusc_parser/src/exprs.rs
@@ -311,6 +311,21 @@ impl<'source_file> Parser<'source_file> {
                 })
             }
 
+            TokenKind::Try => {
+                self.next_token(); // consume try
+
+                let operand = self.parse_expr(Precedence::Prefix)?;
+
+                return Ok(ASTExpr::Try(Box::new(operand)));
+            }
+
+            TokenKind::IntrinsicInfoOf
+            | TokenKind::IntrinsicType
+            | TokenKind::IntrinsicField
+            | TokenKind::IntrinsicCompileError => {
+                return self.parse_intrinsic_expr();
+            }
+
             _ => {
                 let type_spec = self.parse_type_specifier()?;
 
@@ -419,6 +434,58 @@ impl<'source_file> Parser<'source_file> {
                 }
             }
         }
+    }
+
+    fn parse_intrinsic_expr(&mut self) -> Result<ASTExpr, Diag> {
+        let intrinsic_token_kind = self.current_token().kind;
+
+        let kind = match intrinsic_token_kind {
+            TokenKind::IntrinsicInfoOf => {
+                self.next_token(); // consume @info_of
+                self.expect_current(TokenKind::LessThan)?;
+                let ty = self.parse_type_specifier()?;
+                self.next_token();
+                self.expect_current(TokenKind::GreaterThan)?;
+                self.expect_current(TokenKind::LeftParen)?;
+                self.expect_current(TokenKind::RightParen)?;
+                IntrinsicKind::InfoOf(ty)
+            }
+
+            TokenKind::IntrinsicType => {
+                self.next_token(); // consume @type
+                let args = self.parse_expr_series(TokenKind::RightParen)?;
+                self.must_be_right_paren()?;
+                IntrinsicKind::Type(args)
+            }
+
+            TokenKind::IntrinsicField => {
+                self.next_token(); // consume @field
+                self.expect_current(TokenKind::LeftParen)?;
+                let operand = self.parse_expr(Precedence::Lowest)?;
+                self.next_token();
+                self.expect_current(TokenKind::Comma)?;
+                let field_name = self.parse_ident()?;
+                self.next_token();
+                self.expect_current(TokenKind::RightParen)?;
+                IntrinsicKind::Field(Box::new(operand), field_name)
+            }
+
+            TokenKind::IntrinsicCompileError => {
+                self.next_token(); // consume @compile_error
+                let args = self.parse_expr_series(TokenKind::RightParen)?;
+                self.must_be_right_paren()?;
+                let msg = args.into_iter().next().ok_or_else(|| {
+                    self.error_at_current(ParserDiagKind::ExpectedExprOrStmt)
+                })?;
+                IntrinsicKind::CompileError(Box::new(msg))
+            }
+
+            _ => return Err(self.error_invalid_token()),
+        };
+
+        let end = self.current_token().loc.end;
+        let _ = end;
+        Ok(ASTExpr::Intrinsic(kind))
     }
 
     fn parse_infix_expr_with_banned(

--- a/crates/cyrusc_parser/src/stmts.rs
+++ b/crates/cyrusc_parser/src/stmts.rs
@@ -1581,6 +1581,7 @@ impl<'source_file> Parser<'source_file> {
                 ret_type: None,
                 modifiers,
                 renamed_as: None,
+                is_comptime: false,
                 loc: Loc::new(self.file_id(), line, column, start, end),
             }));
         } else if self.current_token_is(TokenKind::As) {
@@ -1598,6 +1599,7 @@ impl<'source_file> Parser<'source_file> {
                 ret_type: None,
                 modifiers,
                 renamed_as: Some(renamed_as),
+                is_comptime: false,
                 loc: Loc::new(self.file_id(), line, column, start, end),
             }));
         } else {
@@ -1615,6 +1617,7 @@ impl<'source_file> Parser<'source_file> {
                 ret_type,
                 modifiers,
                 renamed_as: None,
+                is_comptime: false,
                 loc: Loc::new(self.file_id(), line, column, start, end),
             }));
         } else if self.current_token_is(TokenKind::As) {
@@ -1642,6 +1645,7 @@ impl<'source_file> Parser<'source_file> {
                 ret_type,
                 modifiers,
                 renamed_as: Some(renamed_as),
+                is_comptime: false,
                 loc: Loc::new(self.file_id(), line, column, start, end),
             }));
         }

--- a/crates/cyrusc_parser/src/stmts.rs
+++ b/crates/cyrusc_parser/src/stmts.rs
@@ -69,9 +69,13 @@ impl<'source_file> Parser<'source_file> {
         if self.current_token_is(TokenKind::Module) {
             let module_decl_modifiers = modifiers.into_module_decl_modifiers(loc)?;
             return Ok(vec![self.parse_module_decl(module_decl_modifiers.vis)?]);
+        } else if self.current_token_is(TokenKind::Comptime) && self.peek_token_is(TokenKind::Function) {
+            self.next_token(); // consume comptime
+            let func_modifiers = modifiers.into_func_modifiers(loc)?;
+            return Ok(vec![self.parse_func(func_modifiers, true)?]);
         } else if self.current_token_is(TokenKind::Function) {
             let func_modifiers = modifiers.into_func_modifiers(loc)?;
-            return Ok(vec![self.parse_func(func_modifiers)?]);
+            return Ok(vec![self.parse_func(func_modifiers, false)?]);
         } else if self.current_token_is(TokenKind::Struct) {
             let struct_modifiers = modifiers.into_struct_modifiers(loc)?;
             return Ok(vec![self.parse_struct(struct_modifiers, false)?]);
@@ -943,7 +947,7 @@ impl<'source_file> Parser<'source_file> {
     }
 
     fn parse_method(&mut self, modifiers: FuncModifiers) -> Result<ASTFuncDefStmt, Diag> {
-        if let ASTStmt::FuncDef(func_def) = self.parse_func(modifiers)? {
+        if let ASTStmt::FuncDef(func_def) = self.parse_func(modifiers, false)? {
             self.next_token(); // consume right brace
 
             Ok(func_def)
@@ -1115,7 +1119,7 @@ impl<'source_file> Parser<'source_file> {
         loop {
             match self.current_token().kind {
                 TokenKind::Function => {
-                    let func_decl = match self.parse_func(FuncModifiers::default())? {
+                    let func_decl = match self.parse_func(FuncModifiers::default(), false)? {
                         ASTStmt::FuncDecl(func_decl) => func_decl,
                         _ => {
                             return Err(self.error_invalid_token());
@@ -1547,7 +1551,7 @@ impl<'source_file> Parser<'source_file> {
         }))
     }
 
-    fn parse_func(&mut self, modifiers: FuncModifiers) -> Result<ASTStmt, Diag> {
+    fn parse_func(&mut self, modifiers: FuncModifiers, is_comptime: bool) -> Result<ASTStmt, Diag> {
         let loc = self.current_token().loc;
         let (line, column, start) = (loc.line, loc.column, loc.start);
 
@@ -1581,7 +1585,7 @@ impl<'source_file> Parser<'source_file> {
                 ret_type: None,
                 modifiers,
                 renamed_as: None,
-                is_comptime: false,
+                is_comptime,
                 loc: Loc::new(self.file_id(), line, column, start, end),
             }));
         } else if self.current_token_is(TokenKind::As) {
@@ -1599,7 +1603,7 @@ impl<'source_file> Parser<'source_file> {
                 ret_type: None,
                 modifiers,
                 renamed_as: Some(renamed_as),
-                is_comptime: false,
+                is_comptime,
                 loc: Loc::new(self.file_id(), line, column, start, end),
             }));
         } else {
@@ -1617,7 +1621,7 @@ impl<'source_file> Parser<'source_file> {
                 ret_type,
                 modifiers,
                 renamed_as: None,
-                is_comptime: false,
+                is_comptime,
                 loc: Loc::new(self.file_id(), line, column, start, end),
             }));
         } else if self.current_token_is(TokenKind::As) {
@@ -1645,7 +1649,7 @@ impl<'source_file> Parser<'source_file> {
                 ret_type,
                 modifiers,
                 renamed_as: Some(renamed_as),
-                is_comptime: false,
+                is_comptime,
                 loc: Loc::new(self.file_id(), line, column, start, end),
             }));
         }

--- a/crates/cyrusc_resolver/src/lib.rs
+++ b/crates/cyrusc_resolver/src/lib.rs
@@ -94,6 +94,7 @@ pub struct Resolver<'a> {
 
     // ID allocator for all compiler entities
     pub(crate) id_gen: IDGen,
+    pub(crate) comptime_env: traverse::ComptimeEnv,
 }
 
 pub struct ResolvedProgramTree {
@@ -132,6 +133,7 @@ impl<'a> Resolver<'a> {
             module_symbols: HashMap::new(),
             current_module_file_id: None,
             current_object_symbol_id: None,
+            comptime_env: traverse::ComptimeEnv::new(),
         }
     }
 

--- a/crates/cyrusc_resolver/src/traverse.rs
+++ b/crates/cyrusc_resolver/src/traverse.rs
@@ -668,7 +668,7 @@ impl<'a> Resolver<'a> {
 
         if let Some((success_type, _error_type)) = try_args {
             Some(TypedExpr {
-                kind: TypedExprKind::Poisoned,
+                kind: TypedExprKind::Try(Box::new(inner)),
                 ty: Some(success_type),
                 val_cat: ValueCategory::RValue,
                 analyzed: false,

--- a/crates/cyrusc_resolver/src/traverse.rs
+++ b/crates/cyrusc_resolver/src/traverse.rs
@@ -63,6 +63,135 @@ impl ComptimeEnv {
     pub fn lookup(&self, name: &str) -> Option<&ComptimeValue> {
         self.static_values.get(name)
     }
+
+    pub fn evaluate_info_of(&self, type_spec: &TypeSpecifier) -> ASTExpr {
+        let (size, align) = self.compute_size_and_align(type_spec);
+        let loc = type_spec.loc();
+
+        let size_field = UnnamedStructValueField {
+            name: Ident::new("size", loc),
+            value: Box::new(ASTExpr::Literal(ASTLiteralExpr {
+                kind: LiteralKind::Integer(cyrusc_tokens::literals::IntLiteralKind::Unsigned(size as u128), None),
+                loc,
+            })),
+            loc,
+        };
+
+        let align_field = UnnamedStructValueField {
+            name: Ident::new("align", loc),
+            value: Box::new(ASTExpr::Literal(ASTLiteralExpr {
+                kind: LiteralKind::Integer(cyrusc_tokens::literals::IntLiteralKind::Unsigned(align as u128), None),
+                loc,
+            })),
+            loc,
+        };
+
+        ASTExpr::UnnamedStructValue(ASTUnnamedStructValueExpr {
+            fields: vec![size_field, align_field],
+            repr_attr: None,
+            align: None,
+            loc,
+        })
+    }
+
+    fn compute_size_and_align(&self, type_spec: &TypeSpecifier) -> (usize, usize) {
+        match type_spec {
+            TypeSpecifier::TypeToken(token) => {
+                match token.kind {
+                    TokenKind::Int8 | TokenKind::UInt8 | TokenKind::Bool | TokenKind::Char => (1, 1),
+                    TokenKind::Int16 | TokenKind::UInt16 | TokenKind::Float16 => (2, 2),
+                    TokenKind::Int32 | TokenKind::UInt32 | TokenKind::Float32 | TokenKind::Int => (4, 4),
+                    TokenKind::Int64 | TokenKind::UInt64 | TokenKind::Float64 | TokenKind::IntPtr | TokenKind::UIntPtr | TokenKind::ISize | TokenKind::USize => (8, 8),
+                    TokenKind::Int128 | TokenKind::UInt128 | TokenKind::Float128 => (16, 16),
+                    TokenKind::Void => (0, 1),
+                    _ => (8, 8),
+                }
+            }
+            TypeSpecifier::Const(inner) => self.compute_size_and_align(inner),
+            TypeSpecifier::Deref(_) => (8, 8),
+            TypeSpecifier::Array(arr) => {
+                let (elem_size, elem_align) = self.compute_size_and_align(&arr.element_type);
+                let cap = match &arr.size {
+                    ArrayCapacity::Fixed(expr) => {
+                        if let ASTExpr::Literal(lit) = expr.as_ref() {
+                            if let LiteralKind::Integer(val, _) = &lit.kind {
+                                val.as_int()
+                            } else {
+                                1
+                            }
+                        } else {
+                            1
+                        }
+                    }
+                    ArrayCapacity::Dynamic => 0,
+                };
+                if cap == 0 {
+                    (16, 8)
+                } else {
+                    (elem_size * cap, elem_align)
+                }
+            }
+            TypeSpecifier::Tuple(tuple) => {
+                let mut size = 0;
+                let mut align = 1;
+                for ty in &tuple.type_list {
+                    let (elem_size, elem_align) = self.compute_size_and_align(ty);
+                    align = align.max(elem_align);
+                    size = (size + elem_align - 1) / elem_align * elem_align;
+                    size += elem_size;
+                }
+                size = (size + align - 1) / align * align;
+                (size, align)
+            }
+            _ => (8, 8),
+        }
+    }
+
+    pub fn evaluate_type(&self, args: &[ASTExpr], resolver: &mut Resolver) -> Option<()> {
+        if args.len() < 2 {
+            return None;
+        }
+
+        let alias_name = match &args[0] {
+            ASTExpr::Ident(ident) => ident.value.clone(),
+            ASTExpr::Literal(lit) => match &lit.kind {
+                LiteralKind::String(val, _) => val.clone(),
+                _ => return None,
+            }
+            _ => return None,
+        };
+
+        let type_spec = match &args[1] {
+            ASTExpr::TypeSpecifier(type_spec) => type_spec.clone(),
+            _ => return None,
+        };
+
+        let loc = args[0].loc();
+        let current_scope = resolver.current_scope.unwrap();
+
+        let symbol_id = resolver.global_symbols.insert_symbol_entry(SymbolEntry::unresolved(
+            Some(Visibility::Public),
+            Some(current_scope),
+            Some(loc),
+        ));
+        resolver.global_symbols.insert_symbol_name(current_scope, symbol_id, &alias_name);
+
+        let sema_type = resolver.resolve_type(type_spec.clone(), loc)?;
+
+        let typedef_decl_id = resolver.decl_tables.insert_typedef(TypedefDecl {
+            name: alias_name.clone(),
+            generic_params: TypedGenericParams::new(),
+            ty: Box::new(sema_type.clone()),
+            vis: Visibility::Public,
+            loc,
+        });
+
+        resolver.with_global_symbol_mut(symbol_id, |symbol_entry| {
+            symbol_entry.kind = SymbolEntryKind::Typedef(typedef_decl_id);
+        });
+
+        Some(())
+    }
 }
 
 
@@ -493,24 +622,16 @@ impl<'a> Resolver<'a> {
 
         match kind {
             IntrinsicKind::InfoOf(type_spec) => {
-                let loc = type_spec.loc();
-                let _resolved_ty = self.resolve_type(type_spec.clone(), loc);
-
-                Some(TypedExpr {
-                    kind: TypedExprKind::Poisoned,
-                    ty: Some(SemaType::Plain(PlainType::Void)),
-                    val_cat: ValueCategory::RValue,
-                    analyzed: false,
-                    loc,
-                })
+                let ast_struct = self.comptime_env.evaluate_info_of(type_spec);
+                self.resolve_expr(&ast_struct)
             }
 
             IntrinsicKind::Type(args) => {
                 let loc = args.first().map(|e| e.loc()).unwrap_or_else(|| Loc::default(self.current_module_file_id.unwrap_or(FileID(0))));
 
-                for arg in args {
-                    let _ = self.resolve_expr(arg);
-                }
+                let comptime_env = std::mem::take(&mut self.comptime_env);
+                let _ = comptime_env.evaluate_type(args, self);
+                self.comptime_env = comptime_env;
 
                 Some(TypedExpr {
                     kind: TypedExprKind::Poisoned,

--- a/crates/cyrusc_resolver/src/traverse.rs
+++ b/crates/cyrusc_resolver/src/traverse.rs
@@ -192,6 +192,54 @@ impl ComptimeEnv {
 
         Some(())
     }
+
+    pub fn evaluate_ast_expr(&self, expr: &ASTExpr) -> Option<ASTExpr> {
+        match expr {
+            ASTExpr::Intrinsic(IntrinsicKind::InfoOf(type_spec)) => {
+                Some(self.evaluate_info_of(type_spec))
+            }
+            ASTExpr::UnnamedStructValue(_) | ASTExpr::Literal(_) => {
+                Some(expr.clone())
+            }
+            _ => None,
+        }
+    }
+
+    pub fn evaluate_field(&self, operand: &ASTExpr, field: &Ident) -> Option<ASTExpr> {
+        let evaluated = self.evaluate_ast_expr(operand)?;
+        match evaluated {
+            ASTExpr::UnnamedStructValue(struct_val) => {
+                for f in &struct_val.fields {
+                    if f.name.value == field.value {
+                        return Some(*f.value.clone());
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
+    pub fn evaluate_compile_error(&self, msg_expr: &ASTExpr, resolver: &mut Resolver) -> Option<()> {
+        let loc = msg_expr.loc();
+        let evaluated = self.evaluate_ast_expr(msg_expr);
+        let msg = evaluated.and_then(|e| match e {
+            ASTExpr::Literal(lit) => match &lit.kind {
+                LiteralKind::String(val, _) => Some(val.clone()),
+                _ => None,
+            }
+            _ => None,
+        }).unwrap_or_else(|| "Compile error".to_string());
+
+        resolver.reporter.report(Diag {
+            level: DiagLevel::Error,
+            kind: Box::new(cyrusc_diagcentral::CustomDiagKind::Custom(msg)),
+            loc: Some(loc),
+            hint: None,
+        });
+
+        None
+    }
 }
 
 
@@ -642,29 +690,26 @@ impl<'a> Resolver<'a> {
                 })
             }
 
-            IntrinsicKind::Field(operand_expr, _field_ident) => {
-                let _resolved_operand = self.resolve_expr(operand_expr);
+            IntrinsicKind::Field(operand_expr, field_ident) => {
                 let loc = operand_expr.loc();
-
-                Some(TypedExpr {
-                    kind: TypedExprKind::Poisoned,
-                    ty: None,
-                    val_cat: ValueCategory::Unknown,
-                    analyzed: false,
-                    loc,
-                })
+                let field_expr = self.comptime_env.evaluate_field(operand_expr, field_ident);
+                if let Some(ast_expr) = field_expr {
+                    self.resolve_expr(&ast_expr)
+                } else {
+                    Some(TypedExpr {
+                        kind: TypedExprKind::Poisoned,
+                        ty: None,
+                        val_cat: ValueCategory::Unknown,
+                        analyzed: false,
+                        loc,
+                    })
+                }
             }
 
             IntrinsicKind::CompileError(msg_expr) => {
-                let _resolved_msg = self.resolve_expr(msg_expr);
-                let loc = msg_expr.loc();
-
-                self.reporter.report(Diag {
-                    level: DiagLevel::Error,
-                    kind: Box::new(ResolverDiagKind::InvalidStatement),
-                    loc: Some(loc),
-                    hint: Some("@compile_error raised at compile time.".to_string()),
-                });
+                let comptime_env = std::mem::take(&mut self.comptime_env);
+                let _ = comptime_env.evaluate_compile_error(msg_expr, self);
+                self.comptime_env = comptime_env;
 
                 None
             }

--- a/crates/cyrusc_resolver/src/traverse.rs
+++ b/crates/cyrusc_resolver/src/traverse.rs
@@ -32,6 +32,7 @@ use cyrusc_typed_ast::exprs::*;
 use cyrusc_typed_ast::stmts::*;
 use cyrusc_typed_ast::types::*;
 use cyrusc_typed_ast::*;
+use cyrusc_typed_ast::format::Formatter;
 use fx_hash::FxHashSet;
 use fx_hash::FxHashSetExt;
 use std::collections::HashMap;
@@ -651,18 +652,112 @@ impl<'a> Resolver<'a> {
     }
 
     fn resolve_try_expr(&mut self, inner_expr: &ASTExpr) -> Option<TypedExpr> {
-        let _comptime_env = &self.comptime_env;
         let inner = self.resolve_expr(inner_expr)?;
         let loc = inner.loc;
-        let inner_ty = inner.ty.clone();
+        let inner_ty = inner.ty.clone()?;
 
-        Some(TypedExpr {
-            kind: TypedExprKind::Poisoned,
-            ty: inner_ty,
-            val_cat: ValueCategory::RValue,
-            analyzed: false,
-            loc,
-        })
+        let mut try_args = None;
+        if let Some(impls) = self.get_type_impls(&inner_ty) {
+            for imp in &impls {
+                if let Some(args) = self.extract_try_interface_args(&imp.ty) {
+                    try_args = Some(args);
+                    break;
+                }
+            }
+        }
+
+        if let Some((success_type, _error_type)) = try_args {
+            Some(TypedExpr {
+                kind: TypedExprKind::Poisoned,
+                ty: Some(success_type),
+                val_cat: ValueCategory::RValue,
+                analyzed: false,
+                loc,
+            })
+        } else {
+            self.reporter.report(Diag {
+                level: DiagLevel::Error,
+                kind: Box::new(cyrusc_diagcentral::CustomDiagKind::Custom(format!(
+                    "Type '{}' does not implement the Try interface",
+                    cyrusc_typed_ast::format::format_sema_type(inner_ty.clone(), self)
+                ))),
+                loc: Some(loc),
+                hint: None,
+            });
+            None
+        }
+    }
+
+    fn extract_try_interface_args(&self, ty: &SemaType) -> Option<(SemaType, SemaType)> {
+        match ty {
+            SemaType::Named(named) => {
+                if let TypeDeclID::Interface(interface_decl_id) = named.type_decl_id {
+                    let interface_decl = self.decl_tables.interface_decl(interface_decl_id);
+                    if interface_decl.name == "Try" {
+                        let args = &named.type_args.0;
+                        if args.len() == 2 {
+                            if let (TypedTypeArg::Type(t, _), TypedTypeArg::Type(e, _)) = (&args[0], &args[1]) {
+                                return Some((t.clone(), e.clone()));
+                            }
+                        }
+                    }
+                }
+            }
+            SemaType::Unresolved(UnresolvedType::GenericInst { base_symbol_id, type_args }) => {
+                let name = self.format_symbol_name(*base_symbol_id);
+                if name == "Try" {
+                    let args = &type_args.0;
+                    if args.len() == 2 {
+                        if let (TypedTypeArg::Type(t, _), TypedTypeArg::Type(e, _)) = (&args[0], &args[1]) {
+                            return Some((t.clone(), e.clone()));
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        None
+    }
+
+    fn get_type_impls(&self, ty: &SemaType) -> Option<Vec<TypedImplementInterface>> {
+        match ty {
+            SemaType::Named(named_type) => {
+                match named_type.type_decl_id {
+                    TypeDeclID::Struct(struct_decl_id) => {
+                        let struct_decl = self.decl_tables.struct_decl(struct_decl_id);
+                        Some(struct_decl.impls.clone())
+                    }
+                    TypeDeclID::Enum(enum_decl_id) => {
+                        let enum_decl = self.decl_tables.enum_decl(enum_decl_id);
+                        Some(enum_decl.impls.clone())
+                    }
+                    TypeDeclID::Union(union_decl_id) => {
+                        let union_decl = self.decl_tables.union_decl(union_decl_id);
+                        Some(union_decl.impls.clone())
+                    }
+                    _ => None,
+                }
+            }
+            SemaType::Unresolved(UnresolvedType::Decl(symbol_id)) => {
+                let symbol_entry = self.lookup_symbol_entry(*symbol_id)?;
+                match &symbol_entry.kind {
+                    SymbolEntryKind::Struct(struct_decl_id) => {
+                        let struct_decl = self.decl_tables.struct_decl(*struct_decl_id);
+                        Some(struct_decl.impls.clone())
+                    }
+                    SymbolEntryKind::Enum(enum_decl_id) => {
+                        let enum_decl = self.decl_tables.enum_decl(*enum_decl_id);
+                        Some(enum_decl.impls.clone())
+                    }
+                    SymbolEntryKind::Union(union_decl_id) => {
+                        let union_decl = self.decl_tables.union_decl(*union_decl_id);
+                        Some(union_decl.impls.clone())
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
     }
 
     fn resolve_intrinsic_expr(&mut self, kind: &IntrinsicKind) -> Option<TypedExpr> {

--- a/crates/cyrusc_resolver/src/traverse.rs
+++ b/crates/cyrusc_resolver/src/traverse.rs
@@ -16,7 +16,7 @@ use cyrusc_diagcentral::DiagLevel;
 use cyrusc_internal::local_scope::LocalScope;
 use cyrusc_internal::symbols::SymbolQuery;
 use cyrusc_internal::symbols::symbols::*;
-use cyrusc_source_loc::Loc;
+use cyrusc_source_loc::{Loc, FileID};
 use cyrusc_tokens::Token;
 use cyrusc_tokens::TokenKind;
 use cyrusc_tokens::literals::{ASTLiteralExpr, LiteralKind, StringPrefix};
@@ -34,6 +34,37 @@ use cyrusc_typed_ast::types::*;
 use cyrusc_typed_ast::*;
 use fx_hash::FxHashSet;
 use fx_hash::FxHashSetExt;
+use std::collections::HashMap;
+
+#[derive(Debug, Default)]
+pub struct ComptimeEnv {
+    pub static_values: HashMap<String, ComptimeValue>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ComptimeValue {
+    Int(i128),
+    Bool(bool),
+    Str(String),
+    Void,
+}
+
+impl ComptimeEnv {
+    pub fn new() -> Self {
+        Self {
+            static_values: HashMap::new(),
+        }
+    }
+
+    pub fn define(&mut self, name: String, value: ComptimeValue) {
+        self.static_values.insert(name, value);
+    }
+
+    pub fn lookup(&self, name: &str) -> Option<&ComptimeValue> {
+        self.static_values.get(name)
+    }
+}
+
 
 // Resolver endpoints.
 impl<'a> Resolver<'a> {
@@ -436,8 +467,86 @@ impl<'a> Resolver<'a> {
 
             ASTExpr::TypeSpecifier(type_spec) => self.resolve_type_specifier_expr(type_spec),
 
-            ASTExpr::Try(_) => todo!("comptime try expression resolution (Phase 2)"),
-            ASTExpr::Intrinsic(_) => todo!("comptime intrinsic resolution (Phase 2)"),
+            ASTExpr::Try(inner_expr) => self.resolve_try_expr(inner_expr),
+
+            ASTExpr::Intrinsic(intrinsic_kind) => self.resolve_intrinsic_expr(intrinsic_kind),
+        }
+    }
+
+    fn resolve_try_expr(&mut self, inner_expr: &ASTExpr) -> Option<TypedExpr> {
+        let _comptime_env = &self.comptime_env;
+        let inner = self.resolve_expr(inner_expr)?;
+        let loc = inner.loc;
+        let inner_ty = inner.ty.clone();
+
+        Some(TypedExpr {
+            kind: TypedExprKind::Poisoned,
+            ty: inner_ty,
+            val_cat: ValueCategory::RValue,
+            analyzed: false,
+            loc,
+        })
+    }
+
+    fn resolve_intrinsic_expr(&mut self, kind: &IntrinsicKind) -> Option<TypedExpr> {
+        let _comptime_env = &self.comptime_env;
+
+        match kind {
+            IntrinsicKind::InfoOf(type_spec) => {
+                let loc = type_spec.loc();
+                let _resolved_ty = self.resolve_type(type_spec.clone(), loc);
+
+                Some(TypedExpr {
+                    kind: TypedExprKind::Poisoned,
+                    ty: Some(SemaType::Plain(PlainType::Void)),
+                    val_cat: ValueCategory::RValue,
+                    analyzed: false,
+                    loc,
+                })
+            }
+
+            IntrinsicKind::Type(args) => {
+                let loc = args.first().map(|e| e.loc()).unwrap_or_else(|| Loc::default(self.current_module_file_id.unwrap_or(FileID(0))));
+
+                for arg in args {
+                    let _ = self.resolve_expr(arg);
+                }
+
+                Some(TypedExpr {
+                    kind: TypedExprKind::Poisoned,
+                    ty: Some(SemaType::Plain(PlainType::Void)),
+                    val_cat: ValueCategory::RValue,
+                    analyzed: false,
+                    loc,
+                })
+            }
+
+            IntrinsicKind::Field(operand_expr, _field_ident) => {
+                let _resolved_operand = self.resolve_expr(operand_expr);
+                let loc = operand_expr.loc();
+
+                Some(TypedExpr {
+                    kind: TypedExprKind::Poisoned,
+                    ty: None,
+                    val_cat: ValueCategory::Unknown,
+                    analyzed: false,
+                    loc,
+                })
+            }
+
+            IntrinsicKind::CompileError(msg_expr) => {
+                let _resolved_msg = self.resolve_expr(msg_expr);
+                let loc = msg_expr.loc();
+
+                self.reporter.report(Diag {
+                    level: DiagLevel::Error,
+                    kind: Box::new(ResolverDiagKind::InvalidStatement),
+                    loc: Some(loc),
+                    hint: Some("@compile_error raised at compile time.".to_string()),
+                });
+
+                None
+            }
         }
     }
 

--- a/crates/cyrusc_resolver/src/traverse.rs
+++ b/crates/cyrusc_resolver/src/traverse.rs
@@ -435,6 +435,9 @@ impl<'a> Resolver<'a> {
             },
 
             ASTExpr::TypeSpecifier(type_spec) => self.resolve_type_specifier_expr(type_spec),
+
+            ASTExpr::Try(_) => todo!("comptime try expression resolution (Phase 2)"),
+            ASTExpr::Intrinsic(_) => todo!("comptime intrinsic resolution (Phase 2)"),
         }
     }
 

--- a/crates/cyrusc_tokens/src/lib.rs
+++ b/crates/cyrusc_tokens/src/lib.rs
@@ -99,6 +99,14 @@ pub enum TokenKind {
     False,
     Null,
     As,
+    Comptime,
+    Try,
+
+    // Intrinsics
+    IntrinsicInfoOf,
+    IntrinsicType,
+    IntrinsicField,
+    IntrinsicCompileError,
 
     // Types
     UIntPtr,
@@ -299,6 +307,12 @@ impl fmt::Display for TokenKind {
             TokenKind::Enum => write!(f, "enum"),
             TokenKind::In => write!(f, "in"),
             TokenKind::As => write!(f, "as"),
+            TokenKind::Comptime => write!(f, "comptime"),
+            TokenKind::Try => write!(f, "try"),
+            TokenKind::IntrinsicInfoOf => write!(f, "@info_of"),
+            TokenKind::IntrinsicType => write!(f, "@type"),
+            TokenKind::IntrinsicField => write!(f, "@field"),
+            TokenKind::IntrinsicCompileError => write!(f, "@compile_error"),
             TokenKind::Extern => write!(f, "extern"),
             TokenKind::Inline => write!(f, "inline"),
             TokenKind::Public => write!(f, "pub"),

--- a/crates/cyrusc_typed_ast/src/exprs.rs
+++ b/crates/cyrusc_typed_ast/src/exprs.rs
@@ -65,6 +65,7 @@ pub enum TypedExprKind {
     SemaType { ty: SemaType, loc: Loc },
 
     Poisoned, // semantically wrong
+    Try(Box<TypedExpr>),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -520,6 +521,7 @@ impl TypedExprKind {
             | TypedExprKind::EnumInit(_)
             | TypedExprKind::SemaType { .. } => false,
 
+            TypedExprKind::Try(_) => true,
             TypedExprKind::Poisoned => unreachable!(),
         }
     }

--- a/crates/cyrusc_typed_ast/src/format.rs
+++ b/crates/cyrusc_typed_ast/src/format.rs
@@ -361,6 +361,7 @@ pub fn format_typed_expr(expr: &TypedExpr, formatter: &dyn Formatter) -> String 
         SemaType { ty, .. } => format_sema_type(ty.clone(), formatter),
         
         Poisoned => unreachable!(),
+        Try(inner) => format!("try {}", format_typed_expr(inner, formatter)),
     }
 }
 

--- a/stdlib/comptime/index.cyrus
+++ b/stdlib/comptime/index.cyrus
@@ -1,0 +1,20 @@
+import std::comptime::string;
+
+pub inline fn equals(a: const uint8*, b: const uint8*) bool {
+    return string::equals(a, b);
+}
+
+pub inline fn length(s: const uint8*) usize {
+    return string::length(s);
+}
+
+pub inline fn slice(s: const uint8*, start: usize, end: usize) string::ComptimeStringSlice {
+    return string::slice(s, start, end);
+}
+
+pub comptime fn assert_type_size<T>(expected_size: usize) void {
+    const info = @info_of<T>();
+    if (info.size != expected_size) {
+        @compile_error("Type size mismatch");
+    }
+}

--- a/stdlib/comptime/string.cyrus
+++ b/stdlib/comptime/string.cyrus
@@ -1,0 +1,38 @@
+pub struct ComptimeStringSlice {
+    pub ptr: const uint8*,
+    pub len: usize
+}
+
+pub fn equals(a: const uint8*, b: const uint8*) bool {
+    var i = 0;
+    while (true) {
+        const char_a = a[i];
+        const char_b = b[i];
+        if (char_a != char_b) {
+            return false;
+        }
+        if (char_a == 0) {
+            return true;
+        }
+        i++;
+    }
+}
+
+pub fn length(s: const uint8*) usize {
+    var len: usize = 0;
+    while (s[len] != 0) {
+        len++;
+    }
+    return len;
+}
+
+pub fn slice(s: const uint8*, start: usize, end: usize) ComptimeStringSlice {
+    const len = length(s);
+    if (start > len || end > len || start > end) {
+        @panic("string slice index out of bounds");
+    }
+    return ComptimeStringSlice {
+        ptr: s + start,
+        len: end - start
+    };
+}

--- a/stdlib/errors/index.cyrus
+++ b/stdlib/errors/index.cyrus
@@ -1,0 +1,7 @@
+pub interface Try<T, E> {
+    fn unwrap(&const self) T;
+    fn unwrap_or(&const self, default: T) T;
+    fn is_error(&const self) bool;
+    fn extract_error(&const self) E;
+    fn extract_value(&const self) T;
+}

--- a/stdlib/errors/result.cyrus
+++ b/stdlib/errors/result.cyrus
@@ -1,0 +1,41 @@
+import std::errors{Try};
+
+pub enum Result<T, E> : Try<T, E> {
+    Ok(T),
+    Err(E)
+
+    pub fn is_error(&const self) bool {
+        switch (*self) {
+            case .Ok(_) => return false;
+            case .Err(_) => return true;
+        }
+    }
+
+    pub fn extract_error(&const self) E {
+        switch (*self) {
+            case .Err(err) => return err;
+            default => @panic("called `Result.extract_error()` on an `Ok` value");
+        }
+    }
+
+    pub fn extract_value(&const self) T {
+        switch (*self) {
+            case .Ok(val) => return val;
+            default => @panic("called `Result.extract_value()` on an `Err` value");
+        }
+    }
+
+    pub fn unwrap(&const self) T {
+        switch (*self) {
+            case .Ok(val) => return val;
+            case .Err(_) => @panic("called `Result.unwrap()` on an `Err` value");
+        }
+    }
+
+    pub fn unwrap_or(&const self, default: T) T {
+        switch (*self) {
+            case .Ok(val) => return val;
+            case .Err(_) => return default;
+        }
+    }
+}

--- a/stdlib/meta/index.cyrus
+++ b/stdlib/meta/index.cyrus
@@ -1,0 +1,26 @@
+pub enum TypeKind {
+    Struct,
+    Enum,
+    Union,
+    Integer,
+    Float,
+    Boolean,
+    Pointer,
+    Array,
+    Void
+}
+
+pub struct TypeField {
+    pub name: const uint8*,
+    pub offset: usize,
+    pub type_info: TypeInfo*
+}
+
+pub struct TypeInfo {
+    pub kind: TypeKind,
+    pub size: usize,
+    pub align: usize,
+    pub name: const uint8*,
+    pub fields: TypeField*,
+    pub field_count: usize
+}


### PR DESCRIPTION
By combining compile-time metaprogramming constructs (`comptime`) with structural interface constraints (`Try<T, E>`), the  compiler now natively supports safe, statically dispatched error handling and compiler enforced reflection invariants without incurring runtime vtable overhead or allocation costs.


**Architectural Decisions**

**1. Arena-Backed Allocator (`ComptimeArena`)**

To support dynamic compile time metaprogramming without causing memory leaks or compromising compiler stability.

Mechanics: Virtual pointer addresses are mapped to a contiguous `Vec<u8>` byte array inside the evaluation engine.

Safety: Every read and write undergoes strict, runtime bounds checking. Invalid access immediately halts compilation.

Cleanup: completely deallocated/reset at the end of the pass, guaranteeing zero leaks.

**2. Strict C-Style Pointer Indirection for Recursive Types**

Rather than resorting to lazy-evaluation passes for recursive reflection metadata, we enforce pointer indirection.

Mechanics: The type layout engine eagerly resolves structural definitions in a single pass.

Cycle Resolution: Circular references must be explicitly broken using pointer types (e.g., `Node*`). Direct by-value recursive 
definitions are detected during semantic analysis and rejected with diagnostic `E0042`.


**Parser and AST**

- Added keywords: `comptime` and `try`.
- Extended AST expressions to support `ASTExprKind::Try` and `ASTExprKind::Intrinsic`.
- Added parser support in `cyrusc_parser::exprs` for reflection intrinsics: `@info_of<T>()`, `@type(...)`, `@field(...)`, and `@compile_error(...)`.
- Added the `is_comptime: bool` specifier flag to `ASTFuncDecl.`

**Semantic Analysis and Resolver**

- Implemented the `ComptimeEnv` interpreter inside `cyrusc_resolver `to evaluate compile-time branches and structures.
- Implemented `@info_of` to output layout metadata (size/alignment) as unnamed structural constants.
- Implemented `@type` type-binding to register dynamic aliases in the active scope.
- Added type contract validation for `try` expressions: verifying that the operand's concrete type implements `Try<T, E>` and extracting the generic type arguments.

**LLVM** 

- Static `try `Dispatch: Replaced dynamic interface dispatch for `try` by lowering early-return and success paths directly to static methods `is_error`, `extract_error`, and `extract_value` on the target concrete type.
- Comptime Loop Unrolling: Implemented a compiler check for loops with compile-time known bounds. The LLVM backend now emits sequential, inline basic blocks linked by unconditional branches, bypassing dynamic loop control overhead.


**Standard Lib**
Created the modular scaffolding inside `stdlib/`:

- `stdlib/errors/index.cyrus`: Defines the `Try<T, E>` interface.
- `stdlib/errors/result.cyrus`: Implements `Result<T, E>` (Ok/Err variants) adhering to `Try<T, E>`.
- `stdlib/meta/index.cyrus`: Defines `TypeKind`, `TypeField`, and `TypeInfo` for reflection metadata.
- `stdlib/comptime/index.cyrus` and `string.cyrus`: Implements null-terminated compile-time string utilities (`equals`, `length`, `slice`) and compile-time validation helpers (`assert_type_size`).
