### PR TITLE
fix(parser): diagnose invalid infix operators

### DIFF
--- a/crates/cyrusc_lexer/src/lib.rs
+++ b/crates/cyrusc_lexer/src/lib.rs
@@ -177,6 +177,7 @@ impl<'source_map, 'source_file> Lexer<'source_map, 'source_file> {
             ',' => self.single(TokenKind::Comma),
             ';' => self.single(TokenKind::Semicolon),
             '@' => self.single(TokenKind::At),
+            '`' => self.single(TokenKind::Backtick),
 
             _ => self.invalid_char(),
         }

--- a/crates/cyrusc_parser/src/exprs.rs
+++ b/crates/cyrusc_parser/src/exprs.rs
@@ -73,6 +73,15 @@ impl<'source_file> Parser<'source_file> {
 
             // infix handling (respect precedence)
             let Some(operator_precedence) = token_precedence_of(peek_token.kind.clone()) else {
+                // Keep line breaks as statement boundaries; `@` can begin a builtin statement.
+                if self.current_token().loc.line == peek_token.loc.line
+                    && is_invalid_infix_operator_candidate(&peek_token.kind)
+                {
+                    self.next_token();
+
+                    return Err(self.error_at_current(ParserDiagKind::InvalidInfixOperator(self.current_token().kind)));
+                }
+
                 break;
             };
 
@@ -174,6 +183,10 @@ impl<'source_file> Parser<'source_file> {
 
             TokenKind::At => {
                 return Ok(ASTExpr::Builtin(self.parse_builtin(false)?));
+            }
+
+            TokenKind::Backtick => {
+                return Err(self.error_invalid_token());
             }
 
             TokenKind::Dot => self.parse_unnamed_enum_value()?,
@@ -1475,6 +1488,7 @@ fn can_start_expr(kind: &TokenKind) -> bool {
 
         TokenKind::Undefined
         | TokenKind::Static
+        | TokenKind::Backtick
         | TokenKind::EOF
         | TokenKind::Semicolon
         | TokenKind::RightParen
@@ -1571,6 +1585,10 @@ fn can_start_expr(kind: &TokenKind) -> bool {
         | TokenKind::Section
         | TokenKind::Invalid => false,
     }
+}
+
+fn is_invalid_infix_operator_candidate(token_kind: &TokenKind) -> bool {
+    matches!(token_kind, TokenKind::At | TokenKind::Backtick)
 }
 
 fn is_infix_operator(token_kind: &TokenKind) -> bool {

--- a/crates/cyrusc_parser/src/lib.rs
+++ b/crates/cyrusc_parser/src/lib.rs
@@ -16,6 +16,8 @@ mod exprs;
 mod modifiers;
 mod prec;
 mod stmts;
+#[cfg(test)]
+mod tests;
 
 pub struct Parser<'source_file> {
     source_file: &'source_file SourceFile,
@@ -102,6 +104,16 @@ impl<'source_file> Parser<'source_file> {
     /// Finalizes the program parse by checking for errors.
     #[inline]
     fn finalize_program_parse(&self, program: ProgramTree) -> Result<ProgramTree, ()> {
+        // Backticks are tokenized so the parser can prefer a contextual diagnostic such as
+        // `InvalidInfixOperator`. Preserve their lexical rejection guarantee when parsing would
+        // otherwise succeed, including when recovery consumed one without reporting it.
+        if !self.reporter.has_errors() {
+            for token in self.tokens.iter().filter(|token| token.kind == TokenKind::Backtick) {
+                self.reporter
+                    .report(self.error_at_token(token, ParserDiagKind::InvalidToken(token.kind.clone())));
+            }
+        }
+
         if !self.reporter.has_errors() {
             Ok(program)
         } else {

--- a/crates/cyrusc_parser/src/tests.rs
+++ b/crates/cyrusc_parser/src/tests.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Cyrus Language
+
+use std::sync::Arc;
+
+use crate::Parser;
+use cyrusc_diagcentral::reporter::DiagReporter;
+use cyrusc_lexer::Lexer;
+use cyrusc_source_loc::SourceMap;
+
+#[derive(Debug, PartialEq)]
+struct ObservedDiagnostic {
+    message: String,
+    start: usize,
+    end: usize,
+}
+
+struct ParseOutcome {
+    succeeded: bool,
+    diagnostics: Vec<ObservedDiagnostic>,
+}
+
+#[allow(clippy::arc_with_non_send_sync)]
+fn parse(input: &str) -> ParseOutcome {
+    let source_map = Arc::new(SourceMap::new());
+    let file_id = source_map.add_file("test.cyrus", input.to_string());
+    let source_file = source_map.get_file(file_id).unwrap();
+    let reporter = Arc::new(DiagReporter::new(source_map));
+    let tokens = Lexer::new(&reporter, &source_file).tokenize();
+    let succeeded = Parser::new(reporter.clone(), &source_file, tokens).parse().is_ok();
+    let diagnostics = reporter
+        .diags()
+        .iter()
+        .map(|diag| {
+            let loc = diag.loc.expect("parser diagnostics should identify their source span");
+
+            ObservedDiagnostic {
+                message: diag.kind.to_string(),
+                start: loc.start,
+                end: loc.end,
+            }
+        })
+        .collect();
+
+    ParseOutcome { succeeded, diagnostics }
+}
+
+fn assert_first_diagnostic(input: &str, expected_message: &str, marker: &str) {
+    let outcome = parse(input);
+    let start = input
+        .find(marker)
+        .expect("diagnostic marker should be present in test input");
+
+    assert!(!outcome.succeeded, "input unexpectedly parsed successfully");
+    assert_eq!(
+        outcome.diagnostics.first(),
+        Some(&ObservedDiagnostic {
+            message: expected_message.to_string(),
+            start,
+            end: start + marker.len(),
+        })
+    );
+}
+
+#[test]
+fn test_at_infix_reports_invalid_operator() {
+    let input = "const invalid = 2 @ 4;";
+
+    assert_first_diagnostic(input, "Invalid infix operator '@'.", "@");
+}
+
+#[test]
+fn test_backtick_infix_reports_invalid_operator() {
+    let input = "const invalid = 2 ` 4;";
+
+    assert_first_diagnostic(input, "Invalid infix operator '`'.", "`");
+}
+
+#[test]
+fn test_identifier_after_expression_keeps_statement_boundary_diagnostic() {
+    for input in [
+        "fn test() void {\n    const value = 2 foo;\n}",
+        "fn test() void {\n    const value = 2 foo();\n}",
+        "fn test() void {\n    const value = 2\n    foo;\n}",
+    ] {
+        let outcome = parse(input);
+
+        assert!(!outcome.succeeded, "input unexpectedly parsed successfully");
+        assert_eq!(outcome.diagnostics.first().unwrap().message, "Missing semicolon.");
+        assert!(
+            outcome
+                .diagnostics
+                .iter()
+                .all(|diag| !diag.message.starts_with("Invalid infix operator"))
+        );
+    }
+}
+
+#[test]
+fn test_at_on_following_line_keeps_statement_boundary_diagnostic() {
+    let input = "fn test() void {\n    const value = 2\n    @unreachable();\n}";
+    let outcome = parse(input);
+
+    assert!(!outcome.succeeded, "input unexpectedly parsed successfully");
+    assert_eq!(outcome.diagnostics.first().unwrap().message, "Missing semicolon.");
+    assert!(
+        outcome
+            .diagnostics
+            .iter()
+            .all(|diag| !diag.message.starts_with("Invalid infix operator"))
+    );
+}
+
+#[test]
+fn test_valid_infix_and_builtin_expressions_still_parse() {
+    let input = "fn test() void {\n    const sum = 2 + 4;\n    const converted = @cast(int32, sum);\n}";
+    let outcome = parse(input);
+
+    assert!(outcome.succeeded, "unexpected diagnostics: {:?}", outcome.diagnostics);
+    assert!(outcome.diagnostics.is_empty());
+}
+
+#[test]
+fn test_backtick_prefix_reports_unexpected_token() {
+    let input = "fn test() void {\n    const invalid = `;\n}";
+
+    assert_first_diagnostic(input, "Unexpected token: '`'.", "`");
+}
+
+#[test]
+fn test_silently_consumed_backtick_is_rejected() {
+    let input = "interface C {\n    fn bar(&self) uint8*;\n`}";
+
+    assert_first_diagnostic(input, "Unexpected token: '`'.", "`");
+}

--- a/crates/cyrusc_tokens/src/lib.rs
+++ b/crates/cyrusc_tokens/src/lib.rs
@@ -67,6 +67,7 @@ pub enum TokenKind {
     Or,
     QuestionQuestion,
     At,
+    Backtick,
     Underscore,
     Undefined,
 
@@ -226,6 +227,7 @@ impl fmt::Display for TokenKind {
             TokenKind::LeftBracket => write!(f, "["),
             TokenKind::RightBracket => write!(f, "]"),
             TokenKind::At => write!(f, "@"),
+            TokenKind::Backtick => write!(f, "`"),
             TokenKind::Comma => write!(f, ","),
             TokenKind::DoubleDot => write!(f, ".."),
             TokenKind::TripleDot => write!(f, "..."),


### PR DESCRIPTION
Closes #333.

## What changed

- Preserve backticks as tokens so the parser can diagnose them in context.
- Report `@` and backtick at the Pratt infix boundary as invalid infix operators, using the operator's exact span.
- Keep line breaks as statement boundaries for `@` builtins and retain rejection of any backtick consumed by recovery.
- Add parser regressions for the issue examples, valid operators and builtins, statement boundaries, prefix backticks, and the interface recovery path.

## Design

The Pratt loop stops before tokens without precedence, so the existing `InvalidInfixOperator` diagnostic was unreachable for these inputs. This change handles only the two issue-specific candidates (`@` and backtick) at that boundary. The narrow candidate set avoids reclassifying identifiers or other recovery tokens.

Backticks previously had an unconditional lexer error. Tokenizing them is necessary to make the contextual diagnostic the first error, while a final successful-parse check preserves the original guarantee that a source file containing a real backtick cannot be silently accepted.

Existing cross-line and postfix recovery behavior is intentionally unchanged.

## Validation

- `cargo test -p cyrusc_parser --locked`
- `cargo check -p cyrusc_parser --all-targets --locked`
- `cargo clippy -p cyrusc_parser --all-targets --locked`
- Non-LLVM workspace `cargo check --all-targets --locked`
- Differential parser audit across all 289 repository `.cyrus` files and 210,146 backtick insertion positions; no successful parse retained a backtick token

LLVM-dependent crates were not built locally because LLVM 18 is not installed in the test environment.
