### PR TITLE
Add support for @asm inline assembly (AST and parser)

### DIFF
--- a/crates/cyrusc_ast/src/format.rs
+++ b/crates/cyrusc_ast/src/format.rs
@@ -425,6 +425,7 @@ impl fmt::Display for ASTExpr {
             }
             ASTExpr::UnnamedStructValue(unnamed_struct_value) => write!(f, "{}", unnamed_struct_value),
             ASTExpr::UnnamedUnionValue(unnamed_union_value) => write!(f, "{}", unnamed_union_value),
+            ASTExpr::InlineAsm(asm) => write!(f, "{}", asm),
         }
     }
 }
@@ -498,5 +499,31 @@ impl fmt::Display for ASTUnnamedUnionValueExpr {
         }
 
         write!(f, " }}")
+    }
+}
+
+impl fmt::Display for ASTInlineAsm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "@asm(")?;
+        for (i, t) in self.template.iter().enumerate() {
+            if i > 0 { write!(f, " ")?; }
+            write!(f, "\"{}\"", t)?;
+        }
+        write!(f, " : ")?;
+        for (i, op) in self.outputs.iter().enumerate() {
+            if i > 0 { write!(f, ", ")?; }
+            write!(f, "\"{}\"({})", op.constraint, op.expr)?;
+        }
+        write!(f, " : ")?;
+        for (i, op) in self.inputs.iter().enumerate() {
+            if i > 0 { write!(f, ", ")?; }
+            write!(f, "\"{}\"({})", op.constraint, op.expr)?;
+        }
+        write!(f, " : ")?;
+        for (i, cl) in self.clobbers.iter().enumerate() {
+            if i > 0 { write!(f, ", ")?; }
+            write!(f, "\"{}\"", cl.name)?;
+        }
+        write!(f, ")")
     }
 }

--- a/crates/cyrusc_ast/src/lib.rs
+++ b/crates/cyrusc_ast/src/lib.rs
@@ -51,6 +51,7 @@ pub enum ASTExpr {
     UnnamedStructValue(ASTUnnamedStructValueExpr),
     UnnamedUnionValue(ASTUnnamedUnionValueExpr),
     UnnamedEnumValue(ASTUnnamedEnumValueExpr),
+    InlineAsm(ASTInlineAsm),
 }
 
 #[derive(Debug, Clone)]
@@ -264,6 +265,28 @@ pub struct BuiltinBlock {
     pub loc: Loc,
 }
 
+#[derive(Debug, Clone)]
+pub struct AsmOperand {
+    pub constraint: String,
+    pub expr: Box<ASTExpr>,
+    pub loc: Loc,
+}
+
+#[derive(Debug, Clone)]
+pub struct AsmClobber {
+    pub name: String,
+    pub loc: Loc,
+}
+
+#[derive(Debug, Clone)]
+pub struct ASTInlineAsm {
+    pub template: Vec<String>,
+    pub outputs: Vec<AsmOperand>,
+    pub inputs: Vec<AsmOperand>,
+    pub clobbers: Vec<AsmClobber>,
+    pub loc: Loc,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ASTFuncCallExpr {
     pub operand: Box<ASTExpr>,
@@ -449,6 +472,7 @@ pub enum ASTStmt {
     Defer(ASTDeferStmt),
     Label(ASTLabelStmt),
     Goto(ASTGotoStmt),
+    InlineAsm(ASTInlineAsm),
 }
 
 #[derive(Debug, Clone)]
@@ -1029,7 +1053,8 @@ impl ASTStmt {
             | ASTStmt::Typedef(_)
             | ASTStmt::Defer(_)
             | ASTStmt::Label(_)
-            | ASTStmt::Goto(_) => None,
+            | ASTStmt::Goto(_)
+            | ASTStmt::InlineAsm(_) => None,
         }
     }
 
@@ -1061,7 +1086,8 @@ impl ASTStmt {
             | ASTStmt::Defer(_)
             | ASTStmt::Label(_)
             | ASTStmt::Goto(_)
-            | ASTStmt::Builtin(_) => None,
+            | ASTStmt::Builtin(_)
+            | ASTStmt::InlineAsm(_) => None,
         }
     }
 
@@ -1092,9 +1118,10 @@ impl ASTStmt {
             ASTStmt::Label(label) => label.loc,
             ASTStmt::Goto(goto) => goto.loc,
             ASTStmt::Builtin(builtin) => match builtin {
-                Builtin::BuiltinFunc(builtin_func) => builtin_func.loc,
-                Builtin::BuiltinBlock(builtin_block) => builtin_block.loc,
+            Builtin::BuiltinFunc(builtin_func) => builtin_func.loc,
+            Builtin::BuiltinBlock(builtin_block) => builtin_block.loc,
             },
+            ASTStmt::InlineAsm(asm) => asm.loc,
             ASTStmt::Expr(..) => unreachable!(),
         }
     }
@@ -1590,6 +1617,30 @@ impl PartialEq for ImplementInterface {
 impl Eq for ImplementInterface {}
 impl Eq for BuiltinFunc {}
 impl Eq for BuiltinBlock {}
+impl PartialEq for ASTInlineAsm {
+    fn eq(&self, other: &Self) -> bool {
+        self.template == other.template
+            && self.outputs.len() == other.outputs.len()
+            && self.inputs.len() == other.inputs.len()
+            && self.clobbers.len() == other.clobbers.len()
+    }
+}
+
+impl PartialEq for AsmOperand {
+    fn eq(&self, other: &Self) -> bool {
+        self.constraint == other.constraint && self.expr == other.expr
+    }
+}
+
+impl PartialEq for AsmClobber {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+
+impl Eq for ASTInlineAsm {}
+impl Eq for AsmOperand {}
+impl Eq for AsmClobber {}
 impl Eq for ASTArrayExpr {}
 impl Eq for ASTUntypedArrayExpr {}
 impl Eq for ASTArrayIndexExpr {}

--- a/crates/cyrusc_parser/src/diagnostics.rs
+++ b/crates/cyrusc_parser/src/diagnostics.rs
@@ -91,6 +91,9 @@ pub enum ParserDiagKind {
 
     #[error("Group modifiers cannot be nested.")]
     GroupedModifiersCannotBeNested,
+    
+    #[error("Expected a string literal in inline assembly.")]
+    ExpectedStringLiteral,
 }
 
 impl<'source_file> Parser<'source_file> {

--- a/crates/cyrusc_parser/src/exprs.rs
+++ b/crates/cyrusc_parser/src/exprs.rs
@@ -173,6 +173,9 @@ impl<'source_file> Parser<'source_file> {
             }
 
             TokenKind::At => {
+                if self.peek_token().kind.is_ident_str("asm") {
+                    return Ok(ASTExpr::InlineAsm(self.parse_inline_asm()?));
+                }
                 return Ok(ASTExpr::Builtin(self.parse_builtin(false)?));
             }
 

--- a/crates/cyrusc_parser/src/stmts.rs
+++ b/crates/cyrusc_parser/src/stmts.rs
@@ -22,6 +22,11 @@ impl<'source_file> Parser<'source_file> {
         toplevel: bool,
     ) -> Result<Vec<ASTStmt>, Diag> {
         if self.current_token_is(TokenKind::At) {
+            if self.peek_token().kind.is_ident_str("asm") {
+                let asm = self.parse_inline_asm()?;
+                self.expect_peek_semicolon()?;
+                return Ok(vec![ASTStmt::InlineAsm(asm)]);
+            }
             let mut builtin = self.parse_builtin(toplevel)?;
 
             if let Builtin::BuiltinFunc(builtin_func) = &mut builtin {
@@ -206,6 +211,150 @@ impl<'source_file> Parser<'source_file> {
                 loc: Loc::new(self.file_id(), line, column, start, end),
             }))
         }
+    }
+
+        
+    pub(crate) fn parse_inline_asm(&mut self) -> Result<ASTInlineAsm, Diag> {
+        let loc = self.current_token().loc;
+        let (line, column, start) = (loc.line, loc.column, loc.start);
+
+        self.next_token(); 
+
+        if !self.current_token().kind.is_ident_str("asm") {
+            return Err(self.error_invalid_token());
+        }
+        self.next_token();
+
+        let (template, is_inline) = if self.current_token_is(TokenKind::LeftBrace) {
+            self.next_token(); 
+            let lines = self.parse_asm_template_block()?;
+            self.expect_current(TokenKind::RightBrace)?;
+            (lines, false)
+        } else if self.current_token_is(TokenKind::LeftParen) {
+            self.next_token(); 
+            let s = self.parse_asm_string_literal()?;
+            (vec![s], true)
+        } else {
+            return Err(self.error_invalid_token());
+        };
+
+        let outputs = if self.current_token_is(TokenKind::Colon) {
+            self.next_token();
+            self.parse_asm_operands()?
+        } else {
+            Vec::new()
+        };
+
+        let inputs = if self.current_token_is(TokenKind::Colon) {
+            self.next_token();
+            self.parse_asm_operands()?
+        } else {
+            Vec::new()
+        };
+
+        let clobbers = if self.current_token_is(TokenKind::Colon) {
+            self.next_token();
+            self.parse_asm_clobbers()?
+        } else {
+            Vec::new()
+        };
+
+        if is_inline {
+            self.expect_current(TokenKind::RightParen)?;
+        }
+
+        let end = self.current_token().loc.end;
+
+        Ok(ASTInlineAsm {
+            template,
+            outputs,
+            inputs,
+            clobbers,
+            loc: Loc::new(self.file_id(), line, column, start, end),
+        })
+    }
+
+    fn parse_asm_template_block(&mut self) -> Result<Vec<String>, Diag> {
+        let mut lines = Vec::new();
+        while !self.current_token_is(TokenKind::RightBrace)
+            && !self.current_token_is(TokenKind::EOF)
+        {
+            lines.push(self.parse_asm_string_literal()?);
+        }
+        Ok(lines)
+    }
+
+    fn parse_asm_string_literal(&mut self) -> Result<String, Diag> {
+        use cyrusc_tokens::literals::LiteralKind;
+        match self.current_token().kind.clone() {
+            TokenKind::Literal(lit) => {
+                if let LiteralKind::String(s, _) = lit.kind {
+                    self.next_token();
+                    Ok(s)
+                } else {
+                    Err(self.error_at_current(ParserDiagKind::ExpectedStringLiteral))
+                }
+            }
+            _ => Err(self.error_at_current(ParserDiagKind::ExpectedStringLiteral)),
+        }
+    }
+
+    fn parse_asm_operands(&mut self) -> Result<Vec<AsmOperand>, Diag> {
+        let mut operands = Vec::new();
+        loop {
+            if self.current_token_is(TokenKind::Colon)
+                || self.current_token_is(TokenKind::RightParen)
+                || self.current_token_is(TokenKind::Semicolon)
+                || self.current_token_is(TokenKind::EOF)
+            {
+                break;
+            }
+
+            let loc = self.current_token().loc;
+            let constraint = self.parse_asm_string_literal()?;
+
+            self.expect_current(TokenKind::LeftParen)?;
+            let expr = self.parse_expr(Precedence::Lowest)?;
+            self.next_token();
+            self.expect_current(TokenKind::RightParen)?;
+
+            operands.push(AsmOperand {
+                constraint,
+                expr: Box::new(expr),
+                loc,
+            });
+
+            if self.current_token_is(TokenKind::Comma) {
+                self.next_token();
+            } else {
+                break;
+            }
+        }
+        Ok(operands)
+    }
+
+    fn parse_asm_clobbers(&mut self) -> Result<Vec<AsmClobber>, Diag> {
+        let mut clobbers = Vec::new();
+        loop {
+            if self.current_token_is(TokenKind::Colon)
+                || self.current_token_is(TokenKind::RightParen)
+                || self.current_token_is(TokenKind::Semicolon)
+                || self.current_token_is(TokenKind::EOF)
+            {
+                break;
+            }
+
+            let loc = self.current_token().loc;
+            let name = self.parse_asm_string_literal()?;
+            clobbers.push(AsmClobber { name, loc });
+
+            if self.current_token_is(TokenKind::Comma) {
+                self.next_token();
+            } else {
+                break;
+            }
+        }
+        Ok(clobbers)
     }
 
     fn parse_toplevel_stmts(&mut self) -> Result<Vec<ASTStmt>, Diag> {

--- a/crates/cyrusc_resolver/src/traverse.rs
+++ b/crates/cyrusc_resolver/src/traverse.rs
@@ -211,6 +211,7 @@ impl<'a> Resolver<'a> {
             }
 
             ASTStmt::Defer(_) => unreachable!(),
+            ASTStmt::InlineAsm(_) => todo!(),
         }
     }
 
@@ -435,6 +436,7 @@ impl<'a> Resolver<'a> {
             },
 
             ASTExpr::TypeSpecifier(type_spec) => self.resolve_type_specifier_expr(type_spec),
+            ASTExpr::InlineAsm(_) => todo!(),
         }
     }
 


### PR DESCRIPTION
**AST**
* Added `ASTInlineAsm`, `AsmOperand`, and `AsmClobber` structs.
* Added the `ASTInlineAsm` variant to both `ASTExpr` and `ASTStmt`.

**Parser**
* Implemented the main `parse_inline_asm` routine along with 4 supporting helper functions.
* Added `@asm` parsing to `parse_stmt` and `parse_prefix_expr`