### PR TITLE
feat: stdlib logger, postgres and http server modules

### DIFF
--- a/crates/cyrusc_analyzer/src/builtins.rs
+++ b/crates/cyrusc_analyzer/src/builtins.rs
@@ -477,7 +477,7 @@ impl<'a> AnalysisContext<'a> {
 
     fn analyze_builtin_panic(&mut self, builtin_func: &mut TypedBuiltinFunc) -> Option<SemaType> {
         let param_types = [
-            SemaType::Pointer(Box::new(SemaType::Plain(PlainType::UInt8))), // msg? (char*)
+            SemaType::Pointer(Box::new(SemaType::Const(Box::new(SemaType::Plain(PlainType::UInt8))))), // msg? (const char*)
         ];
 
         for (arg, expected_type) in builtin_func.args.iter_mut().zip(param_types.iter()) {

--- a/stdlib/http/index.cyrus
+++ b/stdlib/http/index.cyrus
@@ -1,0 +1,656 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Cyrus Language
+
+import (
+    std::libc{strlen, strstr, strtoul, tolower, snprintf},
+    std::libc::types{c_int},
+    std::errors{ErrorOr, ErrorStr},
+    std::collections{Vec},
+    std::option{Option},
+    std::mem{Allocator},
+    std::string{String},
+    std::net{TcpStream},
+);
+
+const NUMBER_BUF_SIZE: usize = 24;
+
+pub enum HttpMethod {
+    Get,
+    Head,
+    Post,
+    Put,
+    Delete,
+    Connect,
+    Options,
+    Trace,
+    Patch,
+    Unknown,
+
+    pub fn as_str(self: Self) const uint8* {
+        switch (self) {
+            case .Get => return "GET";
+            case .Head => return "HEAD";
+            case .Post => return "POST";
+            case .Put => return "PUT";
+            case .Delete => return "DELETE";
+            case .Connect => return "CONNECT";
+            case .Options => return "OPTIONS";
+            case .Trace => return "TRACE";
+            case .Patch => return "PATCH";
+            case .Unknown => return "UNKNOWN";
+        }
+    }
+
+    pub fn from_str(value: const uint8*) Self {
+        @assert(value, "method cannot be null");
+
+        switch (value) {
+            case "GET" => return .Get;
+            case "HEAD" => return .Head;
+            case "POST" => return .Post;
+            case "PUT" => return .Put;
+            case "DELETE" => return .Delete;
+            case "CONNECT" => return .Connect;
+            case "OPTIONS" => return .Options;
+            case "TRACE" => return .Trace;
+            case "PATCH" => return .Patch;
+            else => return .Unknown;
+        }
+    }
+}
+
+pub enum HttpStatus {
+    Continue = 100,
+    Ok = 200,
+    Created = 201,
+    Accepted = 202,
+    NoContent = 204,
+    MovedPermanently = 301,
+    Found = 302,
+    NotModified = 304,
+    BadRequest = 400,
+    Unauthorized = 401,
+    Forbidden = 403,
+    NotFound = 404,
+    MethodNotAllowed = 405,
+    RequestTimeout = 408,
+    Conflict = 409,
+    PayloadTooLarge = 413,
+    UriTooLong = 414,
+    UnsupportedMediaType = 415,
+    TooManyRequests = 429,
+    InternalServerError = 500,
+    NotImplemented = 501,
+    BadGateway = 502,
+    ServiceUnavailable = 503,
+    GatewayTimeout = 504,
+    VersionNotSupported = 505,
+
+    [[inline]]
+    pub fn code(self: Self) int32 {
+        return @cast(int32, self);
+    }
+
+    [[inline]]
+    pub fn from_code(code: int32) Self {
+        return @cast(HttpStatus, code);
+    }
+
+    pub fn reason(self: Self) const uint8* {
+        switch (self) {
+            case .Continue => return "Continue";
+            case .Ok => return "OK";
+            case .Created => return "Created";
+            case .Accepted => return "Accepted";
+            case .NoContent => return "No Content";
+            case .MovedPermanently => return "Moved Permanently";
+            case .Found => return "Found";
+            case .NotModified => return "Not Modified";
+            case .BadRequest => return "Bad Request";
+            case .Unauthorized => return "Unauthorized";
+            case .Forbidden => return "Forbidden";
+            case .NotFound => return "Not Found";
+            case .MethodNotAllowed => return "Method Not Allowed";
+            case .RequestTimeout => return "Request Timeout";
+            case .Conflict => return "Conflict";
+            case .PayloadTooLarge => return "Payload Too Large";
+            case .UriTooLong => return "URI Too Long";
+            case .UnsupportedMediaType => return "Unsupported Media Type";
+            case .TooManyRequests => return "Too Many Requests";
+            case .InternalServerError => return "Internal Server Error";
+            case .NotImplemented => return "Not Implemented";
+            case .BadGateway => return "Bad Gateway";
+            case .ServiceUnavailable => return "Service Unavailable";
+            case .GatewayTimeout => return "Gateway Timeout";
+            case .VersionNotSupported => return "HTTP Version Not Supported";
+        }
+    }
+}
+
+pub struct Header {
+    name: String,
+    value: String,
+
+    pub fn new(allocator: Allocator, name: const uint8*, value: const uint8*) Self {
+        return Self {
+            name: String.from_str(allocator, name),
+            value: String.from_str(allocator, value),
+        };
+    }
+
+    [[inline]]
+    pub fn name(self: const Self*) const uint8* {
+        return self->name.as_str_const();
+    }
+
+    [[inline]]
+    pub fn value(self: const Self*) const uint8* {
+        return self->value.as_str_const();
+    }
+
+    [[inline]]
+    pub fn set_value(self: Self*, value: const uint8*) {
+        @assert(value, "header value cannot be null");
+
+        self->value.clear();
+        self->value.push_str(value);
+    }
+
+    [[inline]]
+    pub fn free(self: Self*) {
+        self->name.free();
+        self->value.free();
+    }
+}
+
+pub struct Request {
+    allocator: Allocator,
+    method: HttpMethod,
+    target: String,
+    path: String,
+    query: String,
+    version: String,
+    headers: Vec<Header>,
+    body: String,
+
+    pub fn new(allocator: Allocator) Self {
+        return Self {
+            allocator,
+            method: HttpMethod.Unknown,
+            target: String.new(allocator),
+            path: String.new(allocator),
+            query: String.new(allocator),
+            version: String.new(allocator),
+            headers: Vec.new(allocator),
+            body: String.new(allocator),
+        };
+    }
+
+    pub fn parse(allocator: Allocator, data: const uint8*, len: usize) ErrorOr<Self, ErrorStr> {
+        @assert(data, "data cannot be null");
+
+        var request = Request.new(allocator);
+
+        const first_end = line_end(data, len, 0);
+
+        if (first_end == 0) {
+            request.free();
+            return .Error("malformed http request line");
+        }
+
+        const method_end = find_byte(data, first_end, 0, ' ');
+
+        if (method_end >= first_end) {
+            request.free();
+            return .Error("malformed http request line");
+        }
+
+        const target_start = skip_spaces(data, first_end, method_end);
+        const target_end = find_byte(data, first_end, target_start, ' ');
+
+        if (target_start >= first_end) {
+            request.free();
+            return .Error("malformed http request line");
+        }
+
+        var method_name = copy_range(allocator, data, 0, method_end);
+        request.method = HttpMethod.from_str(method_name.as_str_const());
+        method_name.free();
+
+        request.target.free();
+        request.target = copy_range(allocator, data, target_start, target_end);
+
+        const query_start = find_byte(data, target_end, target_start, '?');
+
+        request.path.free();
+        request.path = copy_range(allocator, data, target_start, query_start);
+
+        request.query.free();
+
+        if (query_start < target_end) {
+            request.query = copy_range(allocator, data, query_start + 1, target_end);
+        } else {
+            request.query = String.new(allocator);
+        }
+
+        const version_start = skip_spaces(data, first_end, target_end);
+
+        request.version.free();
+        request.version = copy_range(allocator, data, version_start, first_end);
+
+        var cursor = next_line(data, len, first_end);
+
+        while (cursor < len) {
+            const current_end = line_end(data, len, cursor);
+
+            if (current_end == cursor) {
+                cursor = next_line(data, len, current_end);
+                break;
+            }
+
+            const colon = find_byte(data, current_end, cursor, ':');
+
+            if (colon < current_end) {
+                const value_start = skip_spaces(data, current_end, colon + 1);
+
+                var name = copy_range(allocator, data, cursor, colon);
+                var value = copy_range(allocator, data, value_start, current_end);
+
+                request.headers.push(Header { name, value });
+            }
+
+            cursor = next_line(data, len, current_end);
+        }
+
+        request.body.free();
+        request.body = copy_range(allocator, data, cursor, len);
+
+        return .Value(request);
+    }
+
+    [[inline]]
+    pub fn method(self: const Self*) HttpMethod {
+        return self->method;
+    }
+
+    [[inline]]
+    pub fn target(self: const Self*) const uint8* {
+        return self->target.as_str_const();
+    }
+
+    [[inline]]
+    pub fn path(self: const Self*) const uint8* {
+        return self->path.as_str_const();
+    }
+
+    [[inline]]
+    pub fn query(self: const Self*) const uint8* {
+        return self->query.as_str_const();
+    }
+
+    [[inline]]
+    pub fn version(self: const Self*) const uint8* {
+        return self->version.as_str_const();
+    }
+
+    [[inline]]
+    pub fn body(self: const Self*) const uint8* {
+        return self->body.as_str_const();
+    }
+
+    [[inline]]
+    pub fn body_len(self: const Self*) usize {
+        return self->body.len();
+    }
+
+    [[inline]]
+    pub fn header_count(self: const Self*) usize {
+        return self->headers.len();
+    }
+
+    pub fn header_at(self: const Self*, index: usize) Option<const Header*> {
+        return self->headers.get_const(index);
+    }
+
+    pub fn header(self: const Self*, name: const uint8*) Option<const uint8*> {
+        @assert(name, "header name cannot be null");
+
+        for (var i: usize = 0; i < self->headers.len(); i += 1) {
+            const current = self->headers.get_const(i).unwrap();
+
+            if (eq_ignore_case(current->name(), name)) {
+                return .Some(current->value());
+            }
+        }
+
+        return .None;
+    }
+
+    pub fn has_header(self: const Self*, name: const uint8*) bool {
+        return self->header(name).is_some();
+    }
+
+    pub fn content_length(self: const Self*) usize {
+        switch (self->header("content-length")) {
+            case .Some(value) => return strtoul(value, null, 10);
+            case .None => return 0;
+        }
+    }
+
+    pub fn keep_alive(self: const Self*) bool {
+        switch (self->header("connection")) {
+            case .Some(value) => return eq_ignore_case(value, "keep-alive");
+            case .None => return false;
+        }
+    }
+
+    pub fn free(self: Self*) {
+        for (var i: usize = 0; i < self->headers.len(); i += 1) {
+            var current = self->headers.get(i).unwrap();
+            current->free();
+        }
+
+        self->headers.free();
+        self->target.free();
+        self->path.free();
+        self->query.free();
+        self->version.free();
+        self->body.free();
+    }
+}
+
+pub struct Response {
+    allocator: Allocator,
+    status: HttpStatus,
+    headers: Vec<Header>,
+    body: String,
+
+    pub fn new(allocator: Allocator) Self {
+        return Self {
+            allocator,
+            status: HttpStatus.Ok,
+            headers: Vec.new(allocator),
+            body: String.new(allocator),
+        };
+    }
+
+    [[inline]]
+    pub fn status(self: const Self*) HttpStatus {
+        return self->status;
+    }
+
+    [[inline]]
+    pub fn set_status(self: Self*, status: HttpStatus) {
+        self->status = status;
+    }
+
+    pub fn set_header(self: Self*, name: const uint8*, value: const uint8*) {
+        @assert(name, "header name cannot be null");
+        @assert(value, "header value cannot be null");
+
+        for (var i: usize = 0; i < self->headers.len(); i += 1) {
+            var current = self->headers.get(i).unwrap();
+
+            if (eq_ignore_case(current->name(), name)) {
+                current->set_value(value);
+                return;
+            }
+        }
+
+        self->headers.push(Header.new(self->allocator, name, value));
+    }
+
+    [[inline]]
+    pub fn set_content_type(self: Self*, value: const uint8*) {
+        self->set_header("Content-Type", value);
+    }
+
+    pub fn header(self: const Self*, name: const uint8*) Option<const uint8*> {
+        @assert(name, "header name cannot be null");
+
+        for (var i: usize = 0; i < self->headers.len(); i += 1) {
+            const current = self->headers.get_const(i).unwrap();
+
+            if (eq_ignore_case(current->name(), name)) {
+                return .Some(current->value());
+            }
+        }
+
+        return .None;
+    }
+
+    [[inline]]
+    pub fn header_count(self: const Self*) usize {
+        return self->headers.len();
+    }
+
+    pub fn set_body(self: Self*, data: const uint8*) {
+        @assert(data, "body cannot be null");
+
+        self->body.clear();
+        self->body.push_str(data);
+    }
+
+    [[inline]]
+    pub fn append_body(self: Self*, data: const uint8*) {
+        @assert(data, "body cannot be null");
+
+        self->body.push_str(data);
+    }
+
+    [[inline]]
+    pub fn body(self: const Self*) const uint8* {
+        return self->body.as_str_const();
+    }
+
+    [[inline]]
+    pub fn body_len(self: const Self*) usize {
+        return self->body.len();
+    }
+
+    pub fn serialize(self: const Self*) String {
+        var out = String.new(self->allocator);
+        var buffer: uint8[NUMBER_BUF_SIZE];
+
+        out.push_str("HTTP/1.1 ");
+        snprintf(&buffer[0], NUMBER_BUF_SIZE, "%d", self->status.code());
+        out.push_str(&buffer[0]);
+        out.push_str(" ");
+        out.push_str(self->status.reason());
+        out.push_str("\r\n");
+
+        for (var i: usize = 0; i < self->headers.len(); i += 1) {
+            const current = self->headers.get_const(i).unwrap();
+
+            if (eq_ignore_case(current->name(), "content-length")) {
+                continue;
+            }
+
+            out.push_str(current->name());
+            out.push_str(": ");
+            out.push_str(current->value());
+            out.push_str("\r\n");
+        }
+
+        out.push_str("Content-Length: ");
+        snprintf(&buffer[0], NUMBER_BUF_SIZE, "%lu", self->body.len());
+        out.push_str(&buffer[0]);
+        out.push_str("\r\n\r\n");
+        out.push_str(self->body.as_str_const());
+
+        return out;
+    }
+
+    pub fn write_to(self: const Self*, stream: TcpStream*) ErrorOr<usize, ErrorStr> {
+        var payload = self->serialize();
+        defer payload.free();
+
+        return stream->write(payload.as_str_const(), payload.len());
+    }
+
+    pub fn reset(self: Self*) {
+        for (var i: usize = 0; i < self->headers.len(); i += 1) {
+            var current = self->headers.get(i).unwrap();
+            current->free();
+        }
+
+        self->headers.clear();
+        self->body.clear();
+        self->status = HttpStatus.Ok;
+    }
+
+    pub fn free(self: Self*) {
+        for (var i: usize = 0; i < self->headers.len(); i += 1) {
+            var current = self->headers.get(i).unwrap();
+            current->free();
+        }
+
+        self->headers.free();
+        self->body.free();
+    }
+}
+
+pub fn eq_ignore_case(left: const uint8*, right: const uint8*) bool {
+    @assert(left, "left cannot be null");
+    @assert(right, "right cannot be null");
+
+    var i: usize = 0;
+
+    while (left[i] != '\0' && right[i] != '\0') {
+        const a = tolower(@cast(c_int, left[i]));
+        const b = tolower(@cast(c_int, right[i]));
+
+        if (a != b) {
+            return false;
+        }
+
+        i += 1;
+    }
+
+    return left[i] == right[i];
+}
+
+pub fn header_terminator(data: const uint8*) Option<usize> {
+    @assert(data, "data cannot be null");
+
+    const found = strstr(data, "\r\n\r\n");
+
+    if (found != null) {
+        return .Some(@cast(usize, found - data) + 4);
+    }
+
+    const relaxed = strstr(data, "\n\n");
+
+    if (relaxed != null) {
+        return .Some(@cast(usize, relaxed - data) + 2);
+    }
+
+    return .None;
+}
+
+pub fn scan_content_length(data: const uint8*, len: usize) usize {
+    @assert(data, "data cannot be null");
+
+    var cursor = next_line(data, len, line_end(data, len, 0));
+
+    while (cursor < len) {
+        const current_end = line_end(data, len, cursor);
+
+        if (current_end == cursor) {
+            return 0;
+        }
+
+        const colon = find_byte(data, current_end, cursor, ':');
+
+        if (colon < current_end) {
+            if (range_eq_ignore_case(data, cursor, colon, "content-length")) {
+                const value_start = skip_spaces(data, current_end, colon + 1);
+                return strtoul(data + value_start, null, 10);
+            }
+        }
+
+        cursor = next_line(data, len, current_end);
+    }
+
+    return 0;
+}
+
+fn range_eq_ignore_case(data: const uint8*, start: usize, end: usize, name: const uint8*) bool {
+    const name_len = strlen(name);
+
+    if (end - start != name_len) {
+        return false;
+    }
+
+    for (var i: usize = 0; i < name_len; i += 1) {
+        const a = tolower(@cast(c_int, data[start + i]));
+        const b = tolower(@cast(c_int, name[i]));
+
+        if (a != b) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+fn find_byte(data: const uint8*, len: usize, start: usize, needle: uint8) usize {
+    var i = start;
+
+    while (i < len) {
+        if (data[i] == needle) {
+            return i;
+        }
+
+        i += 1;
+    }
+
+    return len;
+}
+
+fn skip_spaces(data: const uint8*, len: usize, start: usize) usize {
+    var i = start;
+
+    while (i < len && data[i] == ' ') {
+        i += 1;
+    }
+
+    return i;
+}
+
+fn line_end(data: const uint8*, len: usize, start: usize) usize {
+    var i = start;
+
+    while (i < len && (data[i] != '\r' && data[i] != '\n')) {
+        i += 1;
+    }
+
+    return i;
+}
+
+fn next_line(data: const uint8*, len: usize, end: usize) usize {
+    var i = end;
+
+    if (i < len && data[i] == '\r') {
+        i += 1;
+    }
+
+    if (i < len && data[i] == '\n') {
+        i += 1;
+    }
+
+    return i;
+}
+
+fn copy_range(allocator: Allocator, data: const uint8*, start: usize, end: usize) String {
+    var out = String.new(allocator);
+
+    var i = start;
+
+    while (i < end) {
+        out.push(data[i]);
+        i += 1;
+    }
+
+    return out;
+}

--- a/stdlib/http/router.cyrus
+++ b/stdlib/http/router.cyrus
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Cyrus Language
+
+import (
+    std::http{Request, Response, HttpMethod, HttpStatus},
+    std::collections{Vec},
+    std::option{Option},
+    std::mem{Allocator},
+);
+
+pub type Handler = fn(const Request*, Response*) void;
+
+pub struct Route {
+    method: HttpMethod,
+    path: const uint8*,
+    handler: Handler,
+
+    pub fn new(method: HttpMethod, path: const uint8*, handler: Handler) Self {
+        @assert(path, "route path cannot be null");
+
+        return Self { method, path, handler };
+    }
+
+    [[inline]]
+    pub fn method(self: const Self*) HttpMethod {
+        return self->method;
+    }
+
+    [[inline]]
+    pub fn path(self: const Self*) const uint8* {
+        return self->path;
+    }
+
+    [[inline]]
+    pub fn handler(self: const Self*) Handler {
+        return self->handler;
+    }
+
+    pub fn matches(self: const Self*, method: HttpMethod, path: const uint8*) bool {
+        if (self->method != method) {
+            return false;
+        }
+
+        return path_matches(self->path, path);
+    }
+}
+
+pub struct Router {
+    routes: Vec<Route>,
+    fallback: Option<Handler>,
+
+    pub fn new(allocator: Allocator) Self {
+        return Self {
+            routes: Vec.new(allocator),
+            fallback: .None,
+        };
+    }
+
+    [[inline]]
+    pub fn add(self: Self*, method: HttpMethod, path: const uint8*, handler: Handler) {
+        self->routes.push(Route.new(method, path, handler));
+    }
+
+    [[inline]]
+    pub fn get(self: Self*, path: const uint8*, handler: Handler) {
+        self->add(HttpMethod.Get, path, handler);
+    }
+
+    [[inline]]
+    pub fn head(self: Self*, path: const uint8*, handler: Handler) {
+        self->add(HttpMethod.Head, path, handler);
+    }
+
+    [[inline]]
+    pub fn post(self: Self*, path: const uint8*, handler: Handler) {
+        self->add(HttpMethod.Post, path, handler);
+    }
+
+    [[inline]]
+    pub fn put(self: Self*, path: const uint8*, handler: Handler) {
+        self->add(HttpMethod.Put, path, handler);
+    }
+
+    [[inline]]
+    pub fn delete(self: Self*, path: const uint8*, handler: Handler) {
+        self->add(HttpMethod.Delete, path, handler);
+    }
+
+    [[inline]]
+    pub fn patch(self: Self*, path: const uint8*, handler: Handler) {
+        self->add(HttpMethod.Patch, path, handler);
+    }
+
+    [[inline]]
+    pub fn options(self: Self*, path: const uint8*, handler: Handler) {
+        self->add(HttpMethod.Options, path, handler);
+    }
+
+    [[inline]]
+    pub fn set_fallback(self: Self*, handler: Handler) {
+        self->fallback = .Some(handler);
+    }
+
+    [[inline]]
+    pub fn len(self: const Self*) usize {
+        return self->routes.len();
+    }
+
+    pub fn find(self: const Self*, method: HttpMethod, path: const uint8*) Option<Handler> {
+        for (var i: usize = 0; i < self->routes.len(); i += 1) {
+            const route = self->routes.get_const(i).unwrap();
+
+            if (route->matches(method, path)) {
+                return .Some(route->handler());
+            }
+        }
+
+        return .None;
+    }
+
+    pub fn allows(self: const Self*, path: const uint8*) bool {
+        for (var i: usize = 0; i < self->routes.len(); i += 1) {
+            const route = self->routes.get_const(i).unwrap();
+
+            if (path_matches(route->path(), path)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    pub fn dispatch(self: const Self*, request: const Request*, response: Response*) bool {
+        switch (self->find(request->method(), request->path())) {
+            case .Some(handler) => {
+                handler(request, response);
+                return true;
+            }
+            case .None => {}
+        }
+
+        switch (self->fallback) {
+            case .Some(handler) => {
+                handler(request, response);
+                return true;
+            }
+            case .None => {}
+        }
+
+        if (self->allows(request->path())) {
+            response->set_status(HttpStatus.MethodNotAllowed);
+            response->set_content_type("text/plain");
+            response->set_body("405 Method Not Allowed");
+        } else {
+            response->set_status(HttpStatus.NotFound);
+            response->set_content_type("text/plain");
+            response->set_body("404 Not Found");
+        }
+
+        return false;
+    }
+
+    [[inline]]
+    pub fn free(self: Self*) {
+        self->routes.free();
+    }
+}
+
+pub fn path_matches(pattern: const uint8*, path: const uint8*) bool {
+    @assert(pattern, "pattern cannot be null");
+    @assert(path, "path cannot be null");
+
+    var i: usize = 0;
+
+    while (pattern[i] != '\0') {
+        if (pattern[i] == '*') {
+            return true;
+        }
+
+        if (pattern[i] != path[i]) {
+            return false;
+        }
+
+        i += 1;
+    }
+
+    if (path[i] == '\0') {
+        return true;
+    }
+
+    return path[i] == '/' && path[i + 1] == '\0';
+}

--- a/stdlib/http/server.cyrus
+++ b/stdlib/http/server.cyrus
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Cyrus Language
+
+import (
+    std::http{Request, Response, HttpStatus, header_terminator, scan_content_length},
+    std::net{TcpListener, TcpStream, DEFAULT_BACKLOG},
+    std::errors{ErrorOr, ErrorStr},
+    std::mem{Allocator},
+    std::string{String},
+    std::http::router{Router},
+);
+
+const READ_CHUNK_SIZE: usize = 4096;
+const DEFAULT_MAX_REQUEST_SIZE: usize = 1048576;
+
+pub struct Server {
+    allocator: Allocator,
+    listener: TcpListener,
+    router: Router*,
+    max_request_size: usize,
+    running: bool,
+
+    pub fn bind(
+        allocator: Allocator,
+        router: Router*,
+        address: const uint8*,
+        port: uint16
+    ) ErrorOr<Self, ErrorStr> {
+        @assert(router, "router cannot be null");
+
+        switch (TcpListener.bind(address, port, DEFAULT_BACKLOG)) {
+            case .Value(listener) => {
+                return .Value(Self {
+                    allocator,
+                    listener,
+                    router,
+                    max_request_size: DEFAULT_MAX_REQUEST_SIZE,
+                    running: false,
+                });
+            }
+            case .Error(err) => return .Error(err);
+        }
+    }
+
+    [[inline]]
+    pub fn set_max_request_size(self: Self*, size: usize) {
+        @assert(size != 0, "maximum request size cannot be zero");
+
+        self->max_request_size = size;
+    }
+
+    [[inline]]
+    pub fn is_running(self: const Self*) bool {
+        return self->running;
+    }
+
+    [[inline]]
+    pub fn stop(self: Self*) {
+        self->running = false;
+    }
+
+    pub fn serve_once(self: Self*) ErrorOr<(), ErrorStr> {
+        var stream: TcpStream;
+
+        switch (self->listener.accept()) {
+            case .Value(accepted) => stream = accepted;
+            case .Error(err) => return .Error(err);
+        }
+
+        var raw = String.new(self->allocator);
+
+        switch (self->read_message(&stream, &raw)) {
+            case .Value(_) => {}
+            case .Error(err) => {
+                raw.free();
+                stream.close();
+                return .Error(err);
+            }
+        }
+
+        if (raw.is_empty()) {
+            raw.free();
+            stream.close();
+            return .Value(());
+        }
+
+        switch (Request.parse(self->allocator, raw.as_str_const(), raw.len())) {
+            case .Value(parsed) => {
+                var request = parsed;
+                var response = Response.new(self->allocator);
+
+                self->router->dispatch(&request, &response);
+
+                const result = response.write_to(&stream);
+
+                response.free();
+                request.free();
+                raw.free();
+                stream.close();
+
+                switch (result) {
+                    case .Value(_) => return .Value(());
+                    case .Error(err) => return .Error(err);
+                }
+            }
+            case .Error(err) => {
+                var response = Response.new(self->allocator);
+                response.set_status(HttpStatus.BadRequest);
+                response.set_content_type("text/plain");
+                response.set_body("400 Bad Request");
+                response.write_to(&stream);
+                response.free();
+
+                raw.free();
+                stream.close();
+                return .Error(err);
+            }
+        }
+    }
+
+    pub fn serve(self: Self*) ErrorOr<(), ErrorStr> {
+        if (!self->listener.is_open()) {
+            return .Error("the server listener is closed");
+        }
+
+        self->running = true;
+
+        while (self->running) {
+            switch (self->serve_once()) {
+                case .Value(_) => {}
+                case .Error(_) => {}
+            }
+        }
+
+        return .Value(());
+    }
+
+    fn read_message(self: Self*, stream: TcpStream*, raw: String*) ErrorOr<(), ErrorStr> {
+        var chunk: uint8[READ_CHUNK_SIZE];
+        var headers_end: usize = 0;
+        var expected: usize = 0;
+
+        while (true) {
+            if (headers_end != 0) {
+                if (raw->len() >= headers_end + expected) {
+                    break;
+                }
+            }
+
+            if (raw->len() >= self->max_request_size) {
+                return .Error("http request exceeds the maximum allowed size");
+            }
+
+            var count: usize = 0;
+
+            switch (stream->read(&chunk[0], READ_CHUNK_SIZE - 1)) {
+                case .Value(received) => count = received;
+                case .Error(err) => return .Error(err);
+            }
+
+            if (count == 0) {
+                break;
+            }
+
+            chunk[count] = '\0';
+            raw->push_str(&chunk[0]);
+
+            if (headers_end == 0) {
+                switch (header_terminator(raw->as_str_const())) {
+                    case .Some(index) => {
+                        headers_end = index;
+                        expected = scan_content_length(raw->as_str_const(), raw->len());
+                    }
+                    case .None => {}
+                }
+            }
+        }
+
+        return .Value(());
+    }
+
+    [[inline]]
+    pub fn close(self: Self*) {
+        self->running = false;
+        self->listener.close();
+    }
+}

--- a/stdlib/logger.cyrus
+++ b/stdlib/logger.cyrus
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Cyrus Language
+
+import (
+    std::libc{time, localtime_r, strftime, CTm},
+    std::libc::types{c_long},
+    std::io{Writer},
+);
+
+const TIMESTAMP_BUF_SIZE: usize = 32;
+
+pub enum LogLevel {
+    Trace = 0,
+    Debug = 1,
+    Info = 2,
+    Warn = 3,
+    Error = 4,
+    Fatal = 5,
+    Off = 6,
+
+    [[inline]]
+    pub fn as_num(self: Self) int32 {
+        return @cast(int32, self);
+    }
+
+    [[inline]]
+    pub fn from_num(value: int32) Self {
+        return @cast(LogLevel, value);
+    }
+
+    pub fn as_str(self: Self) const uint8* {
+        switch (self) {
+            case .Trace => return "TRACE";
+            case .Debug => return "DEBUG";
+            case .Info => return "INFO";
+            case .Warn => return "WARN";
+            case .Error => return "ERROR";
+            case .Fatal => return "FATAL";
+            case .Off => return "OFF";
+        }
+    }
+
+    pub fn color(self: Self) const uint8* {
+        switch (self) {
+            case .Trace => return "\x1b[90m";
+            case .Debug => return "\x1b[36m";
+            case .Info => return "\x1b[32m";
+            case .Warn => return "\x1b[33m";
+            case .Error => return "\x1b[31m";
+            case .Fatal => return "\x1b[35m";
+            case .Off => return "";
+        }
+    }
+}
+
+pub struct Logger {
+    writer: Writer,
+    min_level: LogLevel,
+    colored: bool,
+    timestamped: bool,
+    scope: const uint8*,
+
+    pub fn new(writer: Writer) Self {
+        return Self {
+            writer,
+            min_level: LogLevel.Info,
+            colored: false,
+            timestamped: false,
+            scope: null,
+        };
+    }
+
+    pub fn with_level(writer: Writer, min_level: LogLevel) Self {
+        return Self {
+            writer,
+            min_level,
+            colored: false,
+            timestamped: false,
+            scope: null,
+        };
+    }
+
+    [[inline]]
+    pub fn set_level(self: Self*, min_level: LogLevel) {
+        self->min_level = min_level;
+    }
+
+    [[inline]]
+    pub fn level(self: const Self*) LogLevel {
+        return self->min_level;
+    }
+
+    [[inline]]
+    pub fn set_colored(self: Self*, colored: bool) {
+        self->colored = colored;
+    }
+
+    [[inline]]
+    pub fn set_timestamped(self: Self*, timestamped: bool) {
+        self->timestamped = timestamped;
+    }
+
+    [[inline]]
+    pub fn set_scope(self: Self*, scope: const uint8*) {
+        self->scope = scope;
+    }
+
+    [[inline]]
+    pub fn enabled(self: const Self*, level: LogLevel) bool {
+        return level.as_num() >= self->min_level.as_num();
+    }
+
+    pub fn log(self: Self*, level: LogLevel, mesg: const uint8*) {
+        @assert(mesg, "mesg cannot be null");
+
+        if (!self->enabled(level)) {
+            return;
+        }
+
+        var writer = self->writer;
+
+        if (self->colored) {
+            writer.write(level.color());
+        }
+
+        if (self->timestamped) {
+            var buffer: uint8[TIMESTAMP_BUF_SIZE];
+            format_timestamp(&buffer[0], TIMESTAMP_BUF_SIZE);
+            writer.write(&buffer[0]);
+            writer.write_char(' ');
+        }
+
+        writer.write_char('[');
+        writer.write(level.as_str());
+        writer.write_char(']');
+        writer.write_char(' ');
+
+        if (self->scope != null) {
+            writer.write(self->scope);
+            writer.write(": ");
+        }
+
+        writer.write(mesg);
+
+        if (self->colored) {
+            writer.write("\x1b[0m");
+        }
+
+        writer.write_char('\n');
+        writer.flush();
+    }
+
+    [[inline]]
+    pub fn trace(self: Self*, mesg: const uint8*) {
+        self->log(LogLevel.Trace, mesg);
+    }
+
+    [[inline]]
+    pub fn debug(self: Self*, mesg: const uint8*) {
+        self->log(LogLevel.Debug, mesg);
+    }
+
+    [[inline]]
+    pub fn info(self: Self*, mesg: const uint8*) {
+        self->log(LogLevel.Info, mesg);
+    }
+
+    [[inline]]
+    pub fn warn(self: Self*, mesg: const uint8*) {
+        self->log(LogLevel.Warn, mesg);
+    }
+
+    [[inline]]
+    pub fn error(self: Self*, mesg: const uint8*) {
+        self->log(LogLevel.Error, mesg);
+    }
+
+    [[inline]]
+    pub fn fatal(self: Self*, mesg: const uint8*) {
+        self->log(LogLevel.Fatal, mesg);
+    }
+}
+
+pub fn format_timestamp(buffer: uint8*, size: usize) usize {
+    @assert(buffer, "buffer cannot be null");
+
+    var out = buffer;
+    var now: c_long = time(null);
+    var tm: CTm;
+
+    if (localtime_r(&now, &tm) == null) {
+        out[0] = '\0';
+        return 0;
+    }
+
+    return strftime(out, size, "%Y-%m-%d %H:%M:%S", &tm);
+}

--- a/stdlib/net/index.cyrus
+++ b/stdlib/net/index.cyrus
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Cyrus Language
+
+import (
+    std::libc::types{
+        c_int,
+        c_uint,
+        c_char,
+        c_void,
+        c_size,
+        c_ssize
+    },
+    std::libc{errno, strerror},
+    std::errors{ErrorOr, ErrorStr},
+);
+
+pub const AF_INET: c_int = 2;
+pub const AF_INET6: c_int = 10;
+pub const SOCK_STREAM: c_int = 1;
+pub const SOCK_DGRAM: c_int = 2;
+pub const IPPROTO_TCP: c_int = 6;
+pub const SOL_SOCKET: c_int = 1;
+pub const SO_REUSEADDR: c_int = 2;
+pub const SO_KEEPALIVE: c_int = 9;
+pub const SHUT_RD: c_int = 0;
+pub const SHUT_WR: c_int = 1;
+pub const SHUT_RDWR: c_int = 2;
+pub const MSG_NOSIGNAL: c_int = 16384;
+pub const INADDR_ANY: uint32 = 0;
+pub const INADDR_NONE: uint32 = 4294967295;
+pub const DEFAULT_BACKLOG: int32 = 128;
+
+[[repr(c)]]
+pub struct CInAddr {
+    pub s_addr: uint32
+}
+
+[[repr(c)]]
+pub struct CSockAddr {
+    pub sa_family: uint16,
+    pub sa_data: uint8[14]
+}
+
+[[repr(c)]]
+pub struct CSockAddrIn {
+    pub sin_family: uint16,
+    pub sin_port: uint16,
+    pub sin_addr: CInAddr,
+    pub sin_zero: uint8[8]
+}
+
+pub extern "C" {
+    fn socket(domain: c_int, socket_type: c_int, protocol: c_int) c_int;
+    fn bind(sockfd: c_int, addr: const c_void*, addrlen: c_uint) c_int;
+    fn listen(sockfd: c_int, backlog: c_int) c_int;
+    fn accept(sockfd: c_int, addr: c_void*, addrlen: c_uint*) c_int;
+    fn connect(sockfd: c_int, addr: const c_void*, addrlen: c_uint) c_int;
+    fn setsockopt(sockfd: c_int, level: c_int, optname: c_int, optval: const c_void*, optlen: c_uint) c_int;
+    fn getsockopt(sockfd: c_int, level: c_int, optname: c_int, optval: c_void*, optlen: c_uint*) c_int;
+    fn send(sockfd: c_int, buf: const c_void*, len: c_size, flags: c_int) c_ssize;
+    fn recv(sockfd: c_int, buf: c_void*, len: c_size, flags: c_int) c_ssize;
+    fn shutdown(sockfd: c_int, how: c_int) c_int;
+    fn close(fd: c_int) c_int;
+    fn htons(hostshort: uint16) uint16;
+    fn htonl(hostlong: uint32) uint32;
+    fn ntohs(netshort: uint16) uint16;
+    fn ntohl(netlong: uint32) uint32;
+    fn inet_addr(cp: const c_char*) uint32;
+    fn inet_ntoa(addr: CInAddr) c_char*;
+}
+
+[[inline]]
+pub fn last_error() ErrorStr {
+    return strerror(errno);
+}
+
+pub fn make_ipv4_addr(address: const uint8*, port: uint16) ErrorOr<CSockAddrIn, ErrorStr> {
+    @assert(address, "address cannot be null");
+
+    const host = inet_addr(address);
+
+    if (host == INADDR_NONE) {
+        return .Error("invalid ipv4 address");
+    }
+
+    var addr: CSockAddrIn;
+    addr.sin_family = @cast(uint16, AF_INET);
+    addr.sin_port = htons(port);
+    addr.sin_addr = CInAddr { s_addr: host };
+
+    for (var i: usize = 0; i < 8; i += 1) {
+        addr.sin_zero[i] = 0;
+    }
+
+    return .Value(addr);
+}
+
+pub struct TcpStream {
+    fd: c_int,
+
+    [[inline]]
+    pub fn from_fd(fd: c_int) Self {
+        return Self { fd };
+    }
+
+    [[inline]]
+    pub fn fd(self: const Self*) c_int {
+        return self->fd;
+    }
+
+    [[inline]]
+    pub fn is_open(self: const Self*) bool {
+        return self->fd >= 0;
+    }
+
+    pub fn connect(address: const uint8*, port: uint16) ErrorOr<Self, ErrorStr> {
+        var addr: CSockAddrIn;
+
+        switch (make_ipv4_addr(address, port)) {
+            case .Value(value) => addr = value;
+            case .Error(err) => return .Error(err);
+        }
+
+        const fd = socket(AF_INET, SOCK_STREAM, 0);
+
+        if (fd < 0) {
+            return .Error(last_error());
+        }
+
+        if (connect(fd, @cast(void*, &addr), @cast(c_uint, @sizeof(CSockAddrIn))) < 0) {
+            const err = last_error();
+            close(fd);
+            return .Error(err);
+        }
+
+        return .Value(Self { fd });
+    }
+
+    pub fn read(self: Self*, buffer: uint8*, len: usize) ErrorOr<usize, ErrorStr> {
+        @assert(buffer, "buffer cannot be null");
+
+        const received = recv(self->fd, @cast(void*, buffer), len, 0);
+
+        if (received < 0) {
+            return .Error(last_error());
+        }
+
+        return .Value(@cast(usize, received));
+    }
+
+    pub fn write(self: Self*, data: const uint8*, len: usize) ErrorOr<usize, ErrorStr> {
+        @assert(data, "data cannot be null");
+
+        var sent: usize = 0;
+
+        while (sent < len) {
+            const written = send(self->fd, @cast(const void*, data + sent), len - sent, MSG_NOSIGNAL);
+
+            if (written <= 0) {
+                return .Error(last_error());
+            }
+
+            sent += @cast(usize, written);
+        }
+
+        return .Value(sent);
+    }
+
+    [[inline]]
+    pub fn shutdown(self: Self*) {
+        shutdown(self->fd, SHUT_RDWR);
+    }
+
+    [[inline]]
+    pub fn close(self: Self*) {
+        if (self->fd >= 0) {
+            close(self->fd);
+            self->fd = -1;
+        }
+    }
+}
+
+pub struct TcpListener {
+    fd: c_int,
+
+    pub fn bind(address: const uint8*, port: uint16, backlog: int32) ErrorOr<Self, ErrorStr> {
+        var addr: CSockAddrIn;
+
+        switch (make_ipv4_addr(address, port)) {
+            case .Value(value) => addr = value;
+            case .Error(err) => return .Error(err);
+        }
+
+        const fd = socket(AF_INET, SOCK_STREAM, 0);
+
+        if (fd < 0) {
+            return .Error(last_error());
+        }
+
+        var reuse: c_int = 1;
+
+        if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, @cast(void*, &reuse), @cast(c_uint, @sizeof(c_int))) < 0) {
+            const err = last_error();
+            close(fd);
+            return .Error(err);
+        }
+
+        if (bind(fd, @cast(void*, &addr), @cast(c_uint, @sizeof(CSockAddrIn))) < 0) {
+            const err = last_error();
+            close(fd);
+            return .Error(err);
+        }
+
+        if (listen(fd, backlog) < 0) {
+            const err = last_error();
+            close(fd);
+            return .Error(err);
+        }
+
+        return .Value(Self { fd });
+    }
+
+    [[inline]]
+    pub fn fd(self: const Self*) c_int {
+        return self->fd;
+    }
+
+    [[inline]]
+    pub fn is_open(self: const Self*) bool {
+        return self->fd >= 0;
+    }
+
+    pub fn accept(self: Self*) ErrorOr<TcpStream, ErrorStr> {
+        var peer: CSockAddr;
+        var peer_len: c_uint = @cast(c_uint, @sizeof(CSockAddr));
+
+        const fd = accept(self->fd, @cast(void*, &peer), &peer_len);
+
+        if (fd < 0) {
+            return .Error(last_error());
+        }
+
+        return .Value(TcpStream.from_fd(fd));
+    }
+
+    [[inline]]
+    pub fn close(self: Self*) {
+        if (self->fd >= 0) {
+            close(self->fd);
+            self->fd = -1;
+        }
+    }
+}

--- a/stdlib/postgres.cyrus
+++ b/stdlib/postgres.cyrus
@@ -1,0 +1,486 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Cyrus Language
+
+import (
+    std::libc::types{
+        c_int,
+        c_uint,
+        c_char,
+        c_void,
+        c_size
+    },
+    std::errors{ErrorOr, ErrorStr},
+    std::libc{strlen},
+    std::option{Option},
+);
+
+pub type PGconn = uint8[0];
+
+pub type PGresult = uint8[0];
+
+pub extern "C" {
+    fn PQlibVersion() c_int;
+
+    fn PQconnectdb(conninfo: const c_char*) PGconn*;
+    fn PQfinish(conn: PGconn*) c_void;
+    fn PQreset(conn: PGconn*) c_void;
+    fn PQstatus(conn: PGconn*) c_int;
+    fn PQerrorMessage(conn: PGconn*) c_char*;
+    fn PQdb(conn: PGconn*) c_char*;
+    fn PQuser(conn: PGconn*) c_char*;
+    fn PQhost(conn: PGconn*) c_char*;
+    fn PQport(conn: PGconn*) c_char*;
+    fn PQserverVersion(conn: PGconn*) c_int;
+
+    fn PQexec(conn: PGconn*, query: const c_char*) PGresult*;
+
+    fn PQexecParams(
+        conn: PGconn*,
+        command: const c_char*,
+        nparams: c_int,
+        param_types: const c_uint*,
+        param_values: const c_char**,
+        param_lengths: const c_int*,
+        param_formats: const c_int*,
+        result_format: c_int
+    ) PGresult*;
+
+    fn PQresultStatus(res: PGresult*) c_int;
+    fn PQresStatus(status: c_int) c_char*;
+    fn PQresultErrorMessage(res: PGresult*) c_char*;
+    fn PQntuples(res: PGresult*) c_int;
+    fn PQnfields(res: PGresult*) c_int;
+    fn PQfname(res: PGresult*, field_num: c_int) c_char*;
+    fn PQfnumber(res: PGresult*, field_name: const c_char*) c_int;
+    fn PQgetvalue(res: PGresult*, tup_num: c_int, field_num: c_int) c_char*;
+    fn PQgetisnull(res: PGresult*, tup_num: c_int, field_num: c_int) c_int;
+    fn PQgetlength(res: PGresult*, tup_num: c_int, field_num: c_int) c_int;
+    fn PQcmdStatus(res: PGresult*) c_char*;
+    fn PQcmdTuples(res: PGresult*) c_char*;
+    fn PQclear(res: PGresult*) c_void;
+
+    fn PQescapeLiteral(conn: PGconn*, str: const c_char*, len: c_size) c_char*;
+    fn PQescapeIdentifier(conn: PGconn*, str: const c_char*, len: c_size) c_char*;
+    fn PQfreemem(ptr: c_void*) c_void;
+}
+
+pub enum ConnStatus {
+    Ok = 0,
+    Bad = 1,
+    Started = 2,
+    Made = 3,
+    AwaitingResponse = 4,
+    AuthOk = 5,
+    Setenv = 6,
+    SslStartup = 7,
+    Needed = 8,
+    CheckWritable = 9,
+    Consume = 10,
+    GssStartup = 11,
+    CheckTarget = 12,
+    CheckStandby = 13,
+
+    [[inline]]
+    pub fn as_num(self: Self) int32 {
+        return @cast(int32, self);
+    }
+
+    [[inline]]
+    pub fn from_num(value: int32) Self {
+        return @cast(ConnStatus, value);
+    }
+
+    pub fn as_str(self: Self) const uint8* {
+        switch (self) {
+            case .Ok => return "CONNECTION_OK";
+            case .Bad => return "CONNECTION_BAD";
+            case .Started => return "CONNECTION_STARTED";
+            case .Made => return "CONNECTION_MADE";
+            case .AwaitingResponse => return "CONNECTION_AWAITING_RESPONSE";
+            case .AuthOk => return "CONNECTION_AUTH_OK";
+            case .Setenv => return "CONNECTION_SETENV";
+            case .SslStartup => return "CONNECTION_SSL_STARTUP";
+            case .Needed => return "CONNECTION_NEEDED";
+            case .CheckWritable => return "CONNECTION_CHECK_WRITABLE";
+            case .Consume => return "CONNECTION_CONSUME";
+            case .GssStartup => return "CONNECTION_GSS_STARTUP";
+            case .CheckTarget => return "CONNECTION_CHECK_TARGET";
+            case .CheckStandby => return "CONNECTION_CHECK_STANDBY";
+        }
+    }
+}
+
+pub enum ExecStatus {
+    EmptyQuery = 0,
+    CommandOk = 1,
+    TuplesOk = 2,
+    CopyOut = 3,
+    CopyIn = 4,
+    BadResponse = 5,
+    NonFatalError = 6,
+    FatalError = 7,
+    CopyBoth = 8,
+    SingleTuple = 9,
+    PipelineSync = 10,
+    PipelineAborted = 11,
+
+    [[inline]]
+    pub fn as_num(self: Self) int32 {
+        return @cast(int32, self);
+    }
+
+    [[inline]]
+    pub fn from_num(value: int32) Self {
+        return @cast(ExecStatus, value);
+    }
+
+    pub fn as_str(self: Self) const uint8* {
+        switch (self) {
+            case .EmptyQuery => return "PGRES_EMPTY_QUERY";
+            case .CommandOk => return "PGRES_COMMAND_OK";
+            case .TuplesOk => return "PGRES_TUPLES_OK";
+            case .CopyOut => return "PGRES_COPY_OUT";
+            case .CopyIn => return "PGRES_COPY_IN";
+            case .BadResponse => return "PGRES_BAD_RESPONSE";
+            case .NonFatalError => return "PGRES_NONFATAL_ERROR";
+            case .FatalError => return "PGRES_FATAL_ERROR";
+            case .CopyBoth => return "PGRES_COPY_BOTH";
+            case .SingleTuple => return "PGRES_SINGLE_TUPLE";
+            case .PipelineSync => return "PGRES_PIPELINE_SYNC";
+            case .PipelineAborted => return "PGRES_PIPELINE_ABORTED";
+        }
+    }
+
+    [[inline]]
+    pub fn is_ok(self: Self) bool {
+        switch (self) {
+            case .EmptyQuery | .CommandOk | .TuplesOk | .SingleTuple => return true;
+            else => return false;
+        }
+    }
+}
+
+pub struct QueryResult {
+    res: PGresult*,
+
+    [[inline]]
+    pub fn from_raw(res: PGresult*) Self {
+        @assert(res, "result cannot be null");
+        return Self { res };
+    }
+
+    [[inline]]
+    pub fn as_raw(self: const Self*) PGresult* {
+        return self->res;
+    }
+
+    [[inline]]
+    pub fn status(self: const Self*) ExecStatus {
+        return ExecStatus.from_num(PQresultStatus(self->res));
+    }
+
+    [[inline]]
+    pub fn is_ok(self: const Self*) bool {
+        return self->status().is_ok();
+    }
+
+    [[inline]]
+    pub fn error_mesg(self: const Self*) const uint8* {
+        return PQresultErrorMessage(self->res);
+    }
+
+    [[inline]]
+    pub fn command_status(self: const Self*) const uint8* {
+        return PQcmdStatus(self->res);
+    }
+
+    [[inline]]
+    pub fn affected_rows(self: const Self*) const uint8* {
+        return PQcmdTuples(self->res);
+    }
+
+    [[inline]]
+    pub fn rows(self: const Self*) usize {
+        const count = PQntuples(self->res);
+
+        if (count < 0) {
+            return 0;
+        }
+
+        return @cast(usize, count);
+    }
+
+    [[inline]]
+    pub fn cols(self: const Self*) usize {
+        const count = PQnfields(self->res);
+
+        if (count < 0) {
+            return 0;
+        }
+
+        return @cast(usize, count);
+    }
+
+    [[inline]]
+    pub fn is_empty(self: const Self*) bool {
+        return self->rows() == 0;
+    }
+
+    pub fn field_name(self: const Self*, col: usize) Option<const uint8*> {
+        if (col >= self->cols()) {
+            return .None;
+        }
+
+        const name = PQfname(self->res, @cast(c_int, col));
+
+        if (name == null) {
+            return .None;
+        }
+
+        return .Some(name);
+    }
+
+    pub fn field_index(self: const Self*, name: const uint8*) Option<usize> {
+        @assert(name, "field name cannot be null");
+
+        const index = PQfnumber(self->res, name);
+
+        if (index < 0) {
+            return .None;
+        }
+
+        return .Some(@cast(usize, index));
+    }
+
+    pub fn is_null(self: const Self*, row: usize, col: usize) bool {
+        if (row >= self->rows() || col >= self->cols()) {
+            return true;
+        }
+
+        return PQgetisnull(self->res, @cast(c_int, row), @cast(c_int, col)) != 0;
+    }
+
+    pub fn get(self: const Self*, row: usize, col: usize) Option<const uint8*> {
+        if (row >= self->rows() || col >= self->cols()) {
+            return .None;
+        }
+
+        if (self->is_null(row, col)) {
+            return .None;
+        }
+
+        const value = PQgetvalue(self->res, @cast(c_int, row), @cast(c_int, col));
+
+        if (value == null) {
+            return .None;
+        }
+
+        return .Some(value);
+    }
+
+    pub fn get_by_name(self: const Self*, row: usize, name: const uint8*) Option<const uint8*> {
+        switch (self->field_index(name)) {
+            case .Some(col) => return self->get(row, col);
+            case .None => return .None;
+        }
+    }
+
+    pub fn value_len(self: const Self*, row: usize, col: usize) usize {
+        if (row >= self->rows() || col >= self->cols()) {
+            return 0;
+        }
+
+        const len = PQgetlength(self->res, @cast(c_int, row), @cast(c_int, col));
+
+        if (len < 0) {
+            return 0;
+        }
+
+        return @cast(usize, len);
+    }
+
+    [[inline]]
+    pub fn free(self: Self*) {
+        if (self->res != null) {
+            PQclear(self->res);
+            self->res = null;
+        }
+    }
+}
+
+pub struct Connection {
+    conn: PGconn*,
+
+    pub fn open(conninfo: const uint8*) ErrorOr<Self, ErrorStr> {
+        @assert(conninfo, "conninfo cannot be null");
+
+        const conn = PQconnectdb(conninfo);
+
+        if (conn == null) {
+            return .Error("could not allocate a postgres connection");
+        }
+
+        if (PQstatus(conn) != ConnStatus.Ok.as_num()) {
+            PQfinish(conn);
+            return .Error("could not connect to the postgres server");
+        }
+
+        return .Value(Self { conn });
+    }
+
+    pub fn open_unchecked(conninfo: const uint8*) Option<Self> {
+        @assert(conninfo, "conninfo cannot be null");
+
+        const conn = PQconnectdb(conninfo);
+
+        if (conn == null) {
+            return .None;
+        }
+
+        return .Some(Self { conn });
+    }
+
+    [[inline]]
+    pub fn as_raw(self: const Self*) PGconn* {
+        return self->conn;
+    }
+
+    [[inline]]
+    pub fn status(self: const Self*) ConnStatus {
+        return ConnStatus.from_num(PQstatus(self->conn));
+    }
+
+    [[inline]]
+    pub fn is_ok(self: const Self*) bool {
+        return self->status().as_num() == ConnStatus.Ok.as_num();
+    }
+
+    [[inline]]
+    pub fn error_mesg(self: const Self*) const uint8* {
+        return PQerrorMessage(self->conn);
+    }
+
+    [[inline]]
+    pub fn database(self: const Self*) const uint8* {
+        return PQdb(self->conn);
+    }
+
+    [[inline]]
+    pub fn user(self: const Self*) const uint8* {
+        return PQuser(self->conn);
+    }
+
+    [[inline]]
+    pub fn host(self: const Self*) const uint8* {
+        return PQhost(self->conn);
+    }
+
+    [[inline]]
+    pub fn port(self: const Self*) const uint8* {
+        return PQport(self->conn);
+    }
+
+    [[inline]]
+    pub fn server_version(self: const Self*) int32 {
+        return PQserverVersion(self->conn);
+    }
+
+    [[inline]]
+    pub fn reset(self: Self*) {
+        PQreset(self->conn);
+    }
+
+    pub fn exec(self: Self*, query: const uint8*) ErrorOr<QueryResult, ErrorStr> {
+        @assert(query, "query cannot be null");
+
+        const res = PQexec(self->conn, query);
+
+        if (res == null) {
+            return .Error("could not execute the query");
+        }
+
+        var result = QueryResult.from_raw(res);
+
+        if (!result.is_ok()) {
+            result.free();
+            return .Error("the query was rejected by the postgres server");
+        }
+
+        return .Value(result);
+    }
+
+    pub fn exec_params(
+        self: Self*,
+        query: const uint8*,
+        params: const uint8**,
+        nparams: usize
+    ) ErrorOr<QueryResult, ErrorStr> {
+        @assert(query, "query cannot be null");
+
+        const res = PQexecParams(
+            self->conn,
+            query,
+            @cast(c_int, nparams),
+            null,
+            params,
+            null,
+            null,
+            0
+        );
+
+        if (res == null) {
+            return .Error("could not execute the parameterized query");
+        }
+
+        var result = QueryResult.from_raw(res);
+
+        if (!result.is_ok()) {
+            result.free();
+            return .Error("the parameterized query was rejected by the postgres server");
+        }
+
+        return .Value(result);
+    }
+
+    pub fn escape_literal(self: Self*, value: const uint8*) ErrorOr<uint8*, ErrorStr> {
+        @assert(value, "value cannot be null");
+
+        const escaped = PQescapeLiteral(self->conn, value, strlen(value));
+
+        if (escaped == null) {
+            return .Error("could not escape the literal");
+        }
+
+        return .Value(escaped);
+    }
+
+    pub fn escape_identifier(self: Self*, value: const uint8*) ErrorOr<uint8*, ErrorStr> {
+        @assert(value, "value cannot be null");
+
+        const escaped = PQescapeIdentifier(self->conn, value, strlen(value));
+
+        if (escaped == null) {
+            return .Error("could not escape the identifier");
+        }
+
+        return .Value(escaped);
+    }
+
+    [[inline]]
+    pub fn free_escaped(escaped: uint8*) {
+        PQfreemem(escaped);
+    }
+
+    [[inline]]
+    pub fn close(self: Self*) {
+        if (self->conn != null) {
+            PQfinish(self->conn);
+            self->conn = null;
+        }
+    }
+}
+
+[[inline]]
+pub fn lib_version() int32 {
+    return PQlibVersion();
+}

--- a/tests/std/http/parse_request.cyrus
+++ b/tests/std/http/parse_request.cyrus
@@ -1,0 +1,30 @@
+// @stdout: POST /users id=7 HTTP/1.1\n3 localhost text/plain 5 hello\n
+
+import std::mem::libc{LibcAllocator};
+import std::http{Request};
+import std::mem{Allocator};
+import std::libc{printf, strlen};
+
+pub fn main() {
+    var allocator: Allocator = dynamic LibcAllocator.new();
+
+    const raw = "POST /users?id=7 HTTP/1.1\r\nHost: localhost\r\nContent-Type: text/plain\r\nContent-Length: 5\r\n\r\nhello";
+
+    var request = Request.parse(allocator, raw, strlen(raw)).unwrap();
+    defer request.free();
+
+    printf("%s %s %s %s\n",
+        request.method().as_str(),
+        request.path(),
+        request.query(),
+        request.version()
+    );
+
+    printf("%lu %s %s %lu %s\n",
+        request.header_count(),
+        request.header("host").unwrap(),
+        request.header("CONTENT-TYPE").unwrap(),
+        request.content_length(),
+        request.body()
+    );
+}

--- a/tests/std/http/response_serialize.cyrus
+++ b/tests/std/http/response_serialize.cyrus
@@ -1,0 +1,25 @@
+// @stdout: HTTP/1.1 201 Created\nContent-Type: application/json\nX-Powered-By: cyrus\nContent-Length: 13\n\n{"ok":true}
+
+import std::mem::libc{LibcAllocator};
+import std::http{Response, HttpStatus};
+import std::mem{Allocator};
+import std::libc{printf};
+
+pub fn main() {
+    var allocator: Allocator = dynamic LibcAllocator.new();
+
+    var response = Response.new(allocator);
+    defer response.free();
+
+    response.set_status(HttpStatus.Created);
+    response.set_content_type("text/plain");
+    response.set_content_type("application/json");
+    response.set_header("X-Powered-By", "cyrus");
+    response.set_body("{\"ok\":true}");
+    response.append_body("\r\n");
+
+    var payload = response.serialize();
+    defer payload.free();
+
+    printf("%s", payload.as_str());
+}

--- a/tests/std/http/router_dispatch.cyrus
+++ b/tests/std/http/router_dispatch.cyrus
@@ -1,0 +1,44 @@
+// @stdout: 200 home\n200 static\n405 405 Method Not Allowed\n404 404 Not Found\n
+
+import std::mem::libc{LibcAllocator};
+import std::http{Request, Response, HttpStatus};
+import std::http::router{Router};
+import std::mem{Allocator};
+import std::libc{printf, strlen};
+
+fn home(request: const Request*, response: Response*) {
+    response->set_status(HttpStatus.Ok);
+    response->set_body("home");
+}
+
+fn assets(request: const Request*, response: Response*) {
+    response->set_status(HttpStatus.Ok);
+    response->set_body("static");
+}
+
+fn dispatch(allocator: Allocator, router: const Router*, raw: const uint8*) {
+    var request = Request.parse(allocator, raw, strlen(raw)).unwrap();
+    defer request.free();
+
+    var response = Response.new(allocator);
+    defer response.free();
+
+    router->dispatch(&request, &response);
+
+    printf("%d %s\n", response.status().code(), response.body());
+}
+
+pub fn main() {
+    var allocator: Allocator = dynamic LibcAllocator.new();
+
+    var router = Router.new(allocator);
+    defer router.free();
+
+    router.get("/", home);
+    router.get("/assets/*", assets);
+
+    dispatch(allocator, &router, "GET / HTTP/1.1\r\nHost: local\r\n\r\n");
+    dispatch(allocator, &router, "GET /assets/app.css HTTP/1.1\r\nHost: local\r\n\r\n");
+    dispatch(allocator, &router, "POST / HTTP/1.1\r\nHost: local\r\n\r\n");
+    dispatch(allocator, &router, "GET /missing HTTP/1.1\r\nHost: local\r\n\r\n");
+}

--- a/tests/std/http/server_roundtrip.cyrus
+++ b/tests/std/http/server_roundtrip.cyrus
@@ -1,0 +1,42 @@
+// @stdout: HTTP/1.1 200 OK\nContent-Type: text/plain\nContent-Length: 11\n\nhello=cyrus
+
+import std::mem::libc{LibcAllocator};
+import std::http{Request, Response, HttpStatus};
+import std::http::server{Server};
+import std::http::router{Router};
+import std::net{TcpStream};
+import std::mem{Allocator};
+import std::libc{printf, strlen};
+
+fn greet(request: const Request*, response: Response*) {
+    response->set_status(HttpStatus.Ok);
+    response->set_content_type("text/plain");
+    response->set_body("hello=");
+    response->append_body(request->body());
+}
+
+pub fn main() {
+    var allocator: Allocator = dynamic LibcAllocator.new();
+
+    var router = Router.new(allocator);
+    defer router.free();
+
+    router.post("/greet", greet);
+
+    var server = Server.bind(allocator, &router, "127.0.0.1", 47830).unwrap();
+    defer server.close();
+
+    var client = TcpStream.connect("127.0.0.1", 47830).unwrap();
+    defer client.close();
+
+    const request = "POST /greet HTTP/1.1\r\nHost: local\r\nContent-Length: 5\r\n\r\ncyrus";
+    client.write(request, strlen(request));
+
+    server.serve_once().unwrap();
+
+    var inbox: uint8[512];
+    const received = client.read(&inbox[0], 511).unwrap();
+    inbox[received] = '\0';
+
+    printf("%s", &inbox[0]);
+}

--- a/tests/std/logger/log_levels.cyrus
+++ b/tests/std/logger/log_levels.cyrus
@@ -1,0 +1,28 @@
+// @stdout: [INFO] server started\n[WARN] disk almost full\n[ERROR] connection refused\n
+
+import std::mem::libc{LibcAllocator};
+import std::logger{Logger, LogLevel};
+import std::io{Writer, StringWriter};
+import std::mem{Allocator};
+import std::string{String};
+import std::libc{printf};
+
+pub fn main() {
+    var allocator: Allocator = dynamic LibcAllocator.new();
+
+    var buffer = String.new(allocator);
+    defer buffer.free();
+
+    var string_writer = StringWriter.new(&buffer);
+    var writer: Writer = dynamic string_writer;
+
+    var logger = Logger.new(writer);
+
+    logger.trace("not logged");
+    logger.debug("not logged");
+    logger.info("server started");
+    logger.warn("disk almost full");
+    logger.error("connection refused");
+
+    printf("%s", buffer.as_str());
+}

--- a/tests/std/logger/scoped_logger.cyrus
+++ b/tests/std/logger/scoped_logger.cyrus
@@ -1,0 +1,30 @@
+// @stdout: [WARN] db: retrying\n[FATAL] db: unrecoverable\n
+
+import std::mem::libc{LibcAllocator};
+import std::logger{Logger, LogLevel};
+import std::io{Writer, StringWriter};
+import std::mem{Allocator};
+import std::string{String};
+import std::libc{printf};
+
+pub fn main() {
+    var allocator: Allocator = dynamic LibcAllocator.new();
+
+    var buffer = String.new(allocator);
+    defer buffer.free();
+
+    var string_writer = StringWriter.new(&buffer);
+    var writer: Writer = dynamic string_writer;
+
+    var logger = Logger.with_level(writer, LogLevel.Warn);
+    logger.set_scope("db");
+
+    logger.info("connected");
+    logger.warn("retrying");
+    logger.fatal("unrecoverable");
+
+    logger.set_level(LogLevel.Off);
+    logger.fatal("silenced");
+
+    printf("%s", buffer.as_str());
+}

--- a/tests/std/logger/timestamp.cyrus
+++ b/tests/std/logger/timestamp.cyrus
@@ -1,0 +1,25 @@
+// @stdout: 19 true
+
+import std::logger{format_timestamp};
+import std::libc{printf, isdigit};
+import std::libc::types{c_int};
+
+pub fn main() {
+    var buffer: uint8[32];
+
+    const written = format_timestamp(&buffer[0], 32);
+
+    var valid = isdigit(@cast(c_int, buffer[0])) != 0;
+    valid = valid && buffer[4] == '-';
+    valid = valid && buffer[7] == '-';
+    valid = valid && buffer[10] == ' ';
+    valid = valid && buffer[13] == ':';
+    valid = valid && buffer[16] == ':';
+
+    printf("%lu ", written);
+
+    switch (valid) {
+        case true => printf("true\n");
+        case false => printf("false\n");
+    }
+}

--- a/tests/std/net/tcp_loopback.cyrus
+++ b/tests/std/net/tcp_loopback.cyrus
@@ -1,0 +1,29 @@
+// @stdout: ping pong
+
+import std::net{TcpListener, TcpStream};
+import std::libc{printf};
+
+pub fn main() {
+    var listener = TcpListener.bind("127.0.0.1", 47829, 8).unwrap();
+    defer listener.close();
+
+    var client = TcpStream.connect("127.0.0.1", 47829).unwrap();
+    defer client.close();
+
+    var peer = listener.accept().unwrap();
+    defer peer.close();
+
+    client.write("ping", 4);
+
+    var inbox: uint8[16];
+    const received = peer.read(&inbox[0], 15).unwrap();
+    inbox[received] = '\0';
+
+    peer.write("pong", 4);
+
+    var outbox: uint8[16];
+    const answered = client.read(&outbox[0], 15).unwrap();
+    outbox[answered] = '\0';
+
+    printf("%s %s\n", &inbox[0], &outbox[0]);
+}


### PR DESCRIPTION
Adds std::logger (#387), std::postgres (#384) and std::net + std::http (#388).

logger writes through the Writer interface from std::io, so it works with the existing writers as is. net has the socket bindings plus TcpListener/TcpStream. http has request parsing, response building, a router with 404/405 and a blocking server. postgres is libpq bindings with a Connection/QueryResult wrapper, needs -l pq to link.

Tests in tests/std/{logger,net,http}, suite is 304 passed 0 failed. The server test connects to itself over a real socket in the same thread, so no threads needed.

Nothing for postgres in CI since it needs libpq at link time and the workflow only installs llvm/clang. Tested it by hand against a local PostgreSQL 18: insert with affected rows, select by index and by name, NULL rows, exec_params, escaping, and the error paths. Can add libpq-dev to the workflow if you want it covered.

Dropping the @panic analyzer change since you already fixed it, and splitting this into one PR per issue.
