### PR TITLE
feat: implemented logger module in stdlib

### DIFF
--- a/stdlib/logger.cyrus
+++ b/stdlib/logger.cyrus
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Cyrus Language
+
+import (
+    std::libc{time, localtime_r, strftime, CTm},
+    std::libc::types{c_long},
+    std::io{Writer},
+);
+
+const TIMESTAMP_BUF_SIZE: usize = 32;
+
+pub enum LogLevel {
+    Trace = 0,
+    Debug = 1,
+    Info = 2,
+    Warn = 3,
+    Error = 4,
+    Fatal = 5,
+    Off = 6,
+
+    [[inline]]
+    pub fn as_num(self: Self) int32 {
+        return @cast(int32, self);
+    }
+
+    [[inline]]
+    pub fn from_num(value: int32) Self {
+        return @cast(LogLevel, value);
+    }
+
+    pub fn as_str(self: Self) const uint8* {
+        switch (self) {
+            case .Trace => return "TRACE";
+            case .Debug => return "DEBUG";
+            case .Info => return "INFO";
+            case .Warn => return "WARN";
+            case .Error => return "ERROR";
+            case .Fatal => return "FATAL";
+            case .Off => return "OFF";
+        }
+    }
+
+    pub fn color(self: Self) const uint8* {
+        switch (self) {
+            case .Trace => return "\x1b[90m";
+            case .Debug => return "\x1b[36m";
+            case .Info => return "\x1b[32m";
+            case .Warn => return "\x1b[33m";
+            case .Error => return "\x1b[31m";
+            case .Fatal => return "\x1b[35m";
+            case .Off => return "";
+        }
+    }
+}
+
+pub struct Logger {
+    writer: Writer,
+    min_level: LogLevel,
+    colored: bool,
+    timestamped: bool,
+    scope: const uint8*,
+
+    pub fn new(writer: Writer) Self {
+        return Self {
+            writer,
+            min_level: LogLevel.Info,
+            colored: false,
+            timestamped: false,
+            scope: null,
+        };
+    }
+
+    pub fn with_level(writer: Writer, min_level: LogLevel) Self {
+        return Self {
+            writer,
+            min_level,
+            colored: false,
+            timestamped: false,
+            scope: null,
+        };
+    }
+
+    [[inline]]
+    pub fn set_level(self: Self*, min_level: LogLevel) {
+        self->min_level = min_level;
+    }
+
+    [[inline]]
+    pub fn level(self: const Self*) LogLevel {
+        return self->min_level;
+    }
+
+    [[inline]]
+    pub fn set_colored(self: Self*, colored: bool) {
+        self->colored = colored;
+    }
+
+    [[inline]]
+    pub fn set_timestamped(self: Self*, timestamped: bool) {
+        self->timestamped = timestamped;
+    }
+
+    [[inline]]
+    pub fn set_scope(self: Self*, scope: const uint8*) {
+        self->scope = scope;
+    }
+
+    [[inline]]
+    pub fn enabled(self: const Self*, level: LogLevel) bool {
+        return level.as_num() >= self->min_level.as_num();
+    }
+
+    pub fn log(self: Self*, level: LogLevel, mesg: const uint8*) {
+        @assert(mesg, "mesg cannot be null");
+
+        if (!self->enabled(level)) {
+            return;
+        }
+
+        var writer = self->writer;
+
+        if (self->colored) {
+            writer.write(level.color());
+        }
+
+        if (self->timestamped) {
+            var buffer: uint8[TIMESTAMP_BUF_SIZE];
+            format_timestamp(&buffer[0], TIMESTAMP_BUF_SIZE);
+            writer.write(&buffer[0]);
+            writer.write_char(' ');
+        }
+
+        writer.write_char('[');
+        writer.write(level.as_str());
+        writer.write_char(']');
+        writer.write_char(' ');
+
+        if (self->scope != null) {
+            writer.write(self->scope);
+            writer.write(": ");
+        }
+
+        writer.write(mesg);
+
+        if (self->colored) {
+            writer.write("\x1b[0m");
+        }
+
+        writer.write_char('\n');
+        writer.flush();
+    }
+
+    [[inline]]
+    pub fn trace(self: Self*, mesg: const uint8*) {
+        self->log(LogLevel.Trace, mesg);
+    }
+
+    [[inline]]
+    pub fn debug(self: Self*, mesg: const uint8*) {
+        self->log(LogLevel.Debug, mesg);
+    }
+
+    [[inline]]
+    pub fn info(self: Self*, mesg: const uint8*) {
+        self->log(LogLevel.Info, mesg);
+    }
+
+    [[inline]]
+    pub fn warn(self: Self*, mesg: const uint8*) {
+        self->log(LogLevel.Warn, mesg);
+    }
+
+    [[inline]]
+    pub fn error(self: Self*, mesg: const uint8*) {
+        self->log(LogLevel.Error, mesg);
+    }
+
+    [[inline]]
+    pub fn fatal(self: Self*, mesg: const uint8*) {
+        self->log(LogLevel.Fatal, mesg);
+    }
+}
+
+pub fn format_timestamp(buffer: uint8*, size: usize) usize {
+    @assert(buffer, "buffer cannot be null");
+
+    var out = buffer;
+    var now: c_long = time(null);
+    var tm: CTm;
+
+    if (localtime_r(&now, &tm) == null) {
+        out[0] = '\0';
+        return 0;
+    }
+
+    return strftime(out, size, "%Y-%m-%d %H:%M:%S", &tm);
+}

--- a/stdlib/logger.cyrus
+++ b/stdlib/logger.cyrus
@@ -63,7 +63,7 @@ pub struct Logger {
     pub fn new(writer: Writer) Self {
         return Self {
             writer,
-            min_level: LogLevel.Info,
+            min_level: .Info,
             colored: false,
             timestamped: false,
             scope: null,
@@ -152,32 +152,32 @@ pub struct Logger {
 
     [[inline]]
     pub fn trace(self: Self*, mesg: const uint8*) {
-        self->log(LogLevel.Trace, mesg);
+        self->log(.Trace, mesg);
     }
 
     [[inline]]
     pub fn debug(self: Self*, mesg: const uint8*) {
-        self->log(LogLevel.Debug, mesg);
+        self->log(.Debug, mesg);
     }
 
     [[inline]]
     pub fn info(self: Self*, mesg: const uint8*) {
-        self->log(LogLevel.Info, mesg);
+        self->log(.Info, mesg);
     }
 
     [[inline]]
     pub fn warn(self: Self*, mesg: const uint8*) {
-        self->log(LogLevel.Warn, mesg);
+        self->log(.Warn, mesg);
     }
 
     [[inline]]
     pub fn error(self: Self*, mesg: const uint8*) {
-        self->log(LogLevel.Error, mesg);
+        self->log(.Error, mesg);
     }
 
     [[inline]]
     pub fn fatal(self: Self*, mesg: const uint8*) {
-        self->log(LogLevel.Fatal, mesg);
+        self->log(.Fatal, mesg);
     }
 }
 

--- a/tests/std/logger/log_levels.cyrus
+++ b/tests/std/logger/log_levels.cyrus
@@ -1,0 +1,28 @@
+// @stdout: [INFO] server started\n[WARN] disk almost full\n[ERROR] connection refused\n
+
+import std::mem::libc{LibcAllocator};
+import std::logger{Logger, LogLevel};
+import std::io{Writer, StringWriter};
+import std::mem{Allocator};
+import std::string{String};
+import std::libc{printf};
+
+pub fn main() {
+    var allocator: Allocator = dynamic LibcAllocator.new();
+
+    var buffer = String.new(allocator);
+    defer buffer.free();
+
+    var string_writer = StringWriter.new(&buffer);
+    var writer: Writer = dynamic string_writer;
+
+    var logger = Logger.new(writer);
+
+    logger.trace("not logged");
+    logger.debug("not logged");
+    logger.info("server started");
+    logger.warn("disk almost full");
+    logger.error("connection refused");
+
+    printf("%s", buffer.as_str());
+}

--- a/tests/std/logger/scoped_logger.cyrus
+++ b/tests/std/logger/scoped_logger.cyrus
@@ -1,0 +1,30 @@
+// @stdout: [WARN] db: retrying\n[FATAL] db: unrecoverable\n
+
+import std::mem::libc{LibcAllocator};
+import std::logger{Logger, LogLevel};
+import std::io{Writer, StringWriter};
+import std::mem{Allocator};
+import std::string{String};
+import std::libc{printf};
+
+pub fn main() {
+    var allocator: Allocator = dynamic LibcAllocator.new();
+
+    var buffer = String.new(allocator);
+    defer buffer.free();
+
+    var string_writer = StringWriter.new(&buffer);
+    var writer: Writer = dynamic string_writer;
+
+    var logger = Logger.with_level(writer, LogLevel.Warn);
+    logger.set_scope("db");
+
+    logger.info("connected");
+    logger.warn("retrying");
+    logger.fatal("unrecoverable");
+
+    logger.set_level(LogLevel.Off);
+    logger.fatal("silenced");
+
+    printf("%s", buffer.as_str());
+}

--- a/tests/std/logger/timestamp.cyrus
+++ b/tests/std/logger/timestamp.cyrus
@@ -1,0 +1,25 @@
+// @stdout: 19 true
+
+import std::logger{format_timestamp};
+import std::libc{printf, isdigit};
+import std::libc::types{c_int};
+
+pub fn main() {
+    var buffer: uint8[32];
+
+    const written = format_timestamp(&buffer[0], 32);
+
+    var valid = isdigit(@cast(c_int, buffer[0])) != 0;
+    valid = valid && buffer[4] == '-';
+    valid = valid && buffer[7] == '-';
+    valid = valid && buffer[10] == ' ';
+    valid = valid && buffer[13] == ':';
+    valid = valid && buffer[16] == ':';
+
+    printf("%lu ", written);
+
+    switch (valid) {
+        case true => printf("true\n");
+        case false => printf("false\n");
+    }
+}


### PR DESCRIPTION
Closes #387.

LogLevel with Trace..Fatal plus an Off level, and a Logger that writes through the Writer interface from std::io, so StdoutWriter, StderrWriter, StringWriter and MultiWriter all work with it unchanged. Filtering is a numeric compare and Off sits above Fatal so nothing gets through. Colors, timestamps and a scope tag are opt-in and off by default, which keeps the output easy to assert on in tests. Timestamp is time + localtime_r + strftime into a 32 byte stack buffer.

Tests in tests/std/logger cover level filtering, the scope prefix, switching to Off at runtime and the timestamp format. No compiler changes.
