### PR TITLE
test: logger testcases write straight to stdout and stderr

### DIFF
--- a/tests/std/logger/log_levels.cyrus
+++ b/tests/std/logger/log_levels.cyrus
@@ -1,20 +1,11 @@
 // @stdout: [INFO] server started\n[WARN] disk almost full\n[ERROR] connection refused\n
 
-import std::mem::libc{LibcAllocator};
-import std::logger{Logger, LogLevel};
-import std::io{Writer, StringWriter};
-import std::mem{Allocator};
-import std::string{String};
-import std::libc{printf};
+import std::io{Writer, StdoutWriter};
+import std::logger{Logger};
 
 pub fn main() {
-    var allocator: Allocator = dynamic LibcAllocator.new();
-
-    var buffer = String.new(allocator);
-    defer buffer.free();
-
-    var string_writer = StringWriter.new(&buffer);
-    var writer: Writer = dynamic string_writer;
+    var stdout_writer = StdoutWriter.new();
+    var writer: Writer = dynamic stdout_writer;
 
     var logger = Logger.new(writer);
 
@@ -23,6 +14,4 @@ pub fn main() {
     logger.info("server started");
     logger.warn("disk almost full");
     logger.error("connection refused");
-
-    printf("%s", buffer.as_str());
 }

--- a/tests/std/logger/scoped_logger.cyrus
+++ b/tests/std/logger/scoped_logger.cyrus
@@ -1,20 +1,11 @@
-// @stdout: [WARN] db: retrying\n[FATAL] db: unrecoverable\n
+// @stderr: [WARN] db: retrying\n[FATAL] db: unrecoverable\n
 
-import std::mem::libc{LibcAllocator};
+import std::io{Writer, StderrWriter};
 import std::logger{Logger, LogLevel};
-import std::io{Writer, StringWriter};
-import std::mem{Allocator};
-import std::string{String};
-import std::libc{printf};
 
 pub fn main() {
-    var allocator: Allocator = dynamic LibcAllocator.new();
-
-    var buffer = String.new(allocator);
-    defer buffer.free();
-
-    var string_writer = StringWriter.new(&buffer);
-    var writer: Writer = dynamic string_writer;
+    var stderr_writer = StderrWriter.new();
+    var writer: Writer = dynamic stderr_writer;
 
     var logger = Logger.with_level(writer, LogLevel.Warn);
     logger.set_scope("db");
@@ -23,8 +14,6 @@ pub fn main() {
     logger.warn("retrying");
     logger.fatal("unrecoverable");
 
-    logger.set_level(LogLevel.Off);
+    logger.set_level(.Off);
     logger.fatal("silenced");
-
-    printf("%s", buffer.as_str());
 }


### PR DESCRIPTION
Follow up on #471.

The two logger testcases were writing into a String through StringWriter and printing the buffer at the very end, which is a bad thing to show as the first example of the module: in a real program the log lines just pile up in memory and you lose all of them if the process dies. They now use StdoutWriter and StderrWriter directly so each line leaves as it is written, and the tests got shorter as a side effect (28 -> 17 and 30 -> 19 lines) because the allocator, the String and the buffer printing are all gone.

One detail: the scoped test writes to stderr, so its expectation is `// @stderr:` and not `// @stdout:`. test_suite.py compares both streams, so a stderr test with a stdout expectation fails on both sides.

timestamp.cyrus is untouched, it never used a writer.
