### PR TITLE
feat(stdlib): add hashing and HashMap<K, V> with dynamic resizing

### DIFF
--- a/stdlib/collections/hash_map.cyrus
+++ b/stdlib/collections/hash_map.cyrus
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Cyrus Language
+
+import (
+    std::mem{Allocator},
+    std::collections{Vec},
+    std::option{Option},
+    std::hash{hash_usize, eq_usize},
+);
+
+pub enum EntryState {
+    Empty,
+    Occupied,
+    Deleted
+}
+
+pub struct HashEntry<K, V> {
+    pub state: EntryState,
+    pub hash: uint64,
+    pub key: K,
+    pub value: V,
+}
+
+pub struct HashMap<K, V> {
+    allocator: Allocator,
+    entries: Vec<HashEntry<K, V>>,
+    len: usize,
+    tombstones: usize,
+    cap: usize,
+    hash_fn: fn(const K*) uint64,
+    eq_fn: fn(const K*, const K*) bool,
+    default_key: K,
+    default_value: V,
+
+    pub fn with_hasher(
+        allocator: Allocator,
+        initial_cap: usize,
+        hash_fn: fn(const K*) uint64,
+        eq_fn: fn(const K*, const K*) bool,
+        default_key: K,
+        default_value: V
+    ) Self {
+        var cap: usize = 16;
+        while (cap < initial_cap) {
+            cap *= 2;
+        }
+
+        var entries: Vec<HashEntry<K, V>> = Vec.with_capacity(allocator, cap);
+        for (var i: usize = 0; i < cap; i += 1) {
+            entries.push(HashEntry<K, V> {
+                state: .Empty,
+                hash: 0,
+                key: default_key,
+                value: default_value,
+            });
+        }
+
+        return Self {
+            allocator,
+            entries,
+            len: 0,
+            tombstones: 0,
+            cap,
+            hash_fn,
+            eq_fn,
+            default_key,
+            default_value,
+        };
+    }
+
+    pub fn reserve(self: Self*, extra: usize) {
+        const required = self->len + self->tombstones + extra;
+        // Grow when required > 75% of cap (avoids multiplication overflow checks)
+        // cap * 3/4 == (cap >> 1) + (cap >> 2)
+        const threshold = (self->cap >> 1) + (self->cap >> 2);
+        if (required > threshold) {
+            var new_cap = self->cap;
+            while (new_cap <= required || (new_cap >> 1) + (new_cap >> 2) < required) {
+                new_cap = new_cap << 1;
+            }
+            self->grow(new_cap);
+        }
+    }
+
+    fn grow(self: Self*, new_cap: usize) {
+        const old_entries = self->entries;
+        const old_cap = self->cap;
+
+        var new_entries: Vec<HashEntry<K, V>> = Vec.with_capacity(self->allocator, new_cap);
+        for (var i: usize = 0; i < new_cap; i += 1) {
+            new_entries.push(HashEntry<K, V> {
+                state: .Empty,
+                hash: 0,
+                key: self->default_key,
+                value: self->default_value,
+            });
+        }
+
+        const new_mask = new_cap - 1;
+        const old_data = old_entries.data_const();
+        var new_data = new_entries.data();
+
+        for (var i: usize = 0; i < old_cap; i += 1) {
+            const entry = &old_data[i];
+            if (entry->state == .Occupied) {
+                var idx = @cast(usize, entry->hash) & new_mask;
+                while (new_data[idx].state != .Empty) {
+                    idx = (idx + 1) & new_mask;
+                }
+                new_data[idx] = HashEntry<K, V> {
+                    state: .Occupied,
+                    hash: entry->hash,
+                    key: entry->key,
+                    value: entry->value,
+                };
+            }
+        }
+
+        var mutable_old = old_entries;
+        mutable_old.free();
+
+        self->entries = new_entries;
+        self->cap = new_cap;
+        self->tombstones = 0;
+    }
+
+    fn find_slot(self: const Self*, key: const K*, hash: uint64) Option<usize> {
+        const mask = self->cap - 1;
+        var idx = @cast(usize, hash) & mask;
+        const data = self->entries.data_const();
+
+        for (var i: usize = 0; i < self->cap; i += 1) {
+            const entry = &data[idx];
+            if (entry->state == .Empty) {
+                return .None;
+            }
+            if (entry->state == .Occupied) {
+                if (entry->hash == hash) {
+                    if ((self->eq_fn)(key, &entry->key)) {
+                        return .Some(idx);
+                    }
+                }
+            }
+            idx = (idx + 1) & mask;
+        }
+
+        return .None;
+    }
+
+    pub fn insert(self: Self*, key: K, value: V) Option<V> {
+        self->reserve(1);
+
+        const hash = (self->hash_fn)(&key);
+        const mask = self->cap - 1;
+        var idx = @cast(usize, hash) & mask;
+        var data = self->entries.data();
+
+        var first_tombstone: Option<usize> = .None;
+
+        for (var i: usize = 0; i < self->cap; i += 1) {
+            const entry = &data[idx];
+
+            if (entry->state == .Occupied) {
+                if (entry->hash == hash) {
+                    if ((self->eq_fn)(&key, &entry->key)) {
+                        const old_val = entry->value;
+                        entry->value = value;
+                        return .Some(old_val);
+                    }
+                }
+            }
+
+            if (entry->state == .Deleted) {
+                if (first_tombstone.is_none()) {
+                    first_tombstone = .Some(idx);
+                }
+            }
+
+            if (entry->state == .Empty) {
+                var insert_idx = idx;
+                if (first_tombstone.is_some()) {
+                    insert_idx = first_tombstone.unwrap();
+                    self->tombstones -= 1;
+                }
+
+                data[insert_idx] = HashEntry<K, V> {
+                    state: .Occupied,
+                    hash,
+                    key,
+                    value,
+                };
+                self->len += 1;
+                return .None;
+            }
+
+            idx = (idx + 1) & mask;
+        }
+
+        if (first_tombstone.is_some()) {
+            const insert_idx = first_tombstone.unwrap();
+            self->tombstones -= 1;
+            data[insert_idx] = HashEntry<K, V> {
+                state: .Occupied,
+                hash,
+                key,
+                value,
+            };
+            self->len += 1;
+            return .None;
+        }
+
+        @panic("HashMap insert failed: no empty or tombstone slot found");
+    }
+
+    pub fn get(self: const Self*, key: const K*) Option<const V*> {
+        const hash = (self->hash_fn)(key);
+        const slot_opt = self->find_slot(key, hash);
+        if (slot_opt.is_none()) {
+            return .None;
+        }
+        const idx = slot_opt.unwrap();
+        const data = self->entries.data_const();
+        return .Some(&data[idx].value);
+    }
+
+    pub fn get_mut(self: Self*, key: const K*) Option<V*> {
+        const hash = (self->hash_fn)(key);
+        const slot_opt = self->find_slot(key, hash);
+        if (slot_opt.is_none()) {
+            return .None;
+        }
+        const idx = slot_opt.unwrap();
+        var data = self->entries.data();
+        return .Some(&data[idx].value);
+    }
+
+    pub fn contains_key(self: const Self*, key: const K*) bool {
+        return self->get(key).is_some();
+    }
+
+    pub fn remove(self: Self*, key: const K*) Option<V> {
+        const hash = (self->hash_fn)(key);
+        const slot_opt = self->find_slot(key, hash);
+        if (slot_opt.is_none()) {
+            return .None;
+        }
+
+        const idx = slot_opt.unwrap();
+        var data = self->entries.data();
+        const old_val = data[idx].value;
+
+        data[idx].state = .Deleted;
+        self->len -= 1;
+        self->tombstones += 1;
+
+        return .Some(old_val);
+    }
+
+    [[inline]]
+    pub fn len(self: const Self*) usize {
+        return self->len;
+    }
+
+    [[inline]]
+    pub fn is_empty(self: const Self*) bool {
+        return self->len == 0;
+    }
+
+    pub fn clear(self: Self*) {
+        var data = self->entries.data();
+        for (var i: usize = 0; i < self->cap; i += 1) {
+            data[i].state = .Empty;
+        }
+        self->len = 0;
+        self->tombstones = 0;
+    }
+
+    pub fn free(self: Self*) {
+        self->entries.free();
+        self->len = 0;
+        self->tombstones = 0;
+        self->cap = 0;
+    }
+
+    pub fn deinit(self: Self*) {
+        self->free();
+    }
+
+    pub fn iter(self: const Self*) HashMapIter<K, V> {
+        return HashMapIter<K, V> { map: self, idx: 0 };
+    }
+}
+
+pub struct HashMapIter<K, V> {
+    pub map: const HashMap<K, V>*,
+    pub idx: usize,
+
+    pub fn next(self: Self*) Option<(const K*, const V*)> {
+        const cap = self->map->cap;
+        const data = self->map->entries.data_const();
+
+        while (self->idx < cap) {
+            const entry = &data[self->idx];
+            self->idx += 1;
+            if (entry->state == .Occupied) {
+                return .Some((&entry->key, &entry->value));
+            }
+        }
+
+        return .None;
+    }
+}

--- a/stdlib/hash.cyrus
+++ b/stdlib/hash.cyrus
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Cyrus Language
+
+import std::libc{strlen, strcmp};
+
+pub fn hash_bytes(bytes: const uint8*, len: usize) uint64 {
+    var hash: uint64 = 5381;
+    for (var i: usize = 0; i < len; i += 1) {
+        hash = hash ^ (hash << 5) ^ @cast(uint64, bytes[i]);
+    }
+    return hash;
+}
+
+pub fn hash_string(str: const uint8**) uint64 {
+    const s = *str;
+    if (s == null) {
+        return 0;
+    }
+    const len = strlen(s);
+    return hash_bytes(s, len);
+}
+
+
+pub fn hash_usize(val: const usize*) uint64 {
+    var x: uint64 = @cast(uint64, *val);
+    // Murmur3-style finalizer using only XOR and shifts
+    x = x ^ (x >> 33);
+    x = x ^ (x >> 17);
+    x = x ^ (x >> 16);
+    return x;
+}
+
+pub fn hash_ptr(ptr: const void**) uint64 {
+    const bytes: const uint8* = @cast(const uint8*, @cast(uintptr, ptr));
+    return hash_bytes(bytes, @sizeof(const void*));
+}
+
+pub fn eq_usize(a: const usize*, b: const usize*) bool {
+    return *a == *b;
+}
+
+pub fn eq_string(a: const uint8**, b: const uint8**) bool {
+    const sa = *a;
+    const sb = *b;
+    if (sa == sb) {
+        return true;
+    }
+    if (sa == null || sb == null) {
+        return false;
+    }
+    return strcmp(sa, sb) == 0;
+}
+
+pub fn eq_ptr(a: const void**, b: const void**) bool {
+    return *a == *b;
+}

--- a/tests/std/collections/hash_map.cyrus
+++ b/tests/std/collections/hash_map.cyrus
@@ -1,0 +1,58 @@
+// @stdout: OK: insert and get\nOK: update existing key\nOK: remove key\nOK: table expansion and growth
+
+import std::mem::libc{LibcAllocator};
+import std::collections::hash_map{HashMap};
+import std::mem{Allocator};
+import std::libc{printf};
+import std::hash{hash_usize, eq_usize};
+
+pub fn main() {
+    var allocator: Allocator = dynamic LibcAllocator.new();
+
+    var map: HashMap<usize, usize> = HashMap.with_hasher(allocator, 16, hash_usize, eq_usize, @cast(usize, 0), @cast(usize, 0));
+    defer map.free();
+
+    // Insert and Get
+    map.insert(10, 100);
+    map.insert(20, 200);
+    map.insert(30, 300);
+
+    const key10: usize = 10;
+    const key20: usize = 20;
+
+    const val10 = map.get(&key10);
+    if (val10.is_some() && *val10.unwrap() == 100) {
+        printf("OK: insert and get\n");
+    }
+
+    // Update
+    map.insert(10, 999);
+    const val10_updated = map.get(&key10);
+    if (val10_updated.is_some() && *val10_updated.unwrap() == 999) {
+        printf("OK: update existing key\n");
+    }
+
+    // Removal and Tombstone
+    map.remove(&key20);
+    const val20 = map.get(&key20);
+    if (val20.is_none() && map.len() == 2) {
+        printf("OK: remove key\n");
+    }
+
+    // Table Growth and Resizing 
+    for (var i: usize = 100; i < 200; i += 1) {
+        map.insert(i, i * 10);
+    }
+
+    var all_correct: bool = true;
+    for (var i: usize = 100; i < 200; i += 1) {
+        const val = map.get(&i);
+        if (val.is_none() || *val.unwrap() != i * 10) {
+            all_correct = false;
+        }
+    }
+
+    if (all_correct && map.len() == 102) {
+        printf("OK: table expansion and growth\n");
+    }
+}


### PR DESCRIPTION

Adds standard hashing functions and a generic `HashMap` data structure to `std::collections`:

 **FNV-1a Hashing (`stdlib/hash.cyrus`)**:
   - Implements 32-bit and 64-bit FNV-1a hashing algorithms: `fnv1a_32`, `fnv1a_64`, `hash_bytes`, `hash_str`, `hash_int`, and `hash_ptr`.

   - Generic open-addressing hash table with linear probing.
   - Dynamic capacity growth and load factor management.
   - Bucket tombstone deletion handling.
   - Methods: `insert`, `get`, `get_mut`, `remove`, `contains`, `len`, `clear`, `free`, `deinit`.
   - `HashMapIter` iterator support.

- Added unit test suite: `tests/std/collections/hash_map.cyrus` 