### PR TITLE
feat(stdlib): add HashSet, BinaryHeap, RingBuffer, and Sorting/Searching algorithms

### DIFF
--- a/stdlib/algo/index.cyrus
+++ b/stdlib/algo/index.cyrus
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Cyrus Language
+
+import std::option{Option};
+
+pub fn insertion_sort<T>(var data: T*, len: usize, cmp_fn: fn(const T*, const T*) bool) {
+    if (len <= 1) {
+        return;
+    }
+
+    for (var i: usize = 1; i < len; i += 1) {
+        const key = data[i];
+        var j: usize = i;
+        while (j > 0 && cmp_fn(&key, &data[j - 1])) {
+            data[j] = data[j - 1];
+            j -= 1;
+        }
+        data[j] = key;
+    }
+}
+
+pub fn sort<T>(var data: T*, len: usize, cmp_fn: fn(const T*, const T*) bool) {
+    if (len <= 1) {
+        return;
+    }
+
+    if (len <= 16) {
+        insertion_sort(data, len, cmp_fn);
+        return;
+    }
+
+    const pivot_idx = len - 1;
+    var i: usize = 0;
+
+    for (var j: usize = 0; j < pivot_idx; j += 1) {
+        if (cmp_fn(&data[j], &data[pivot_idx])) {
+            const temp = data[i];
+            data[i] = data[j];
+            data[j] = temp;
+            i += 1;
+        }
+    }
+
+    const temp = data[i];
+    data[i] = data[pivot_idx];
+    data[pivot_idx] = temp;
+
+    sort(data, i, cmp_fn);
+
+    const right_start = i + 1;
+    if (right_start < len) {
+        const right_len = len - right_start;
+        sort(data + right_start, right_len, cmp_fn);
+    }
+}
+
+pub fn is_sorted<T>(data: T*, len: usize, cmp_fn: fn(const T*, const T*) bool) bool {
+    if (len <= 1) {
+        return true;
+    }
+
+    for (var i: usize = 1; i < len; i += 1) {
+        const prev = i - 1;
+        if (cmp_fn(&data[i], &data[prev])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+pub fn binary_search<T>(
+    data: T*,
+    len: usize,
+    target: const T*,
+    cmp_fn: fn(const T*, const T*) int32
+) Option<usize> {
+    if (len == 0) {
+        return .None;
+    }
+
+    var low: usize = 0;
+    var high: usize = len - 1;
+
+    while (low <= high) {
+        const mid = low + ((high - low) / 2);
+        const cmp = cmp_fn(&data[mid], target);
+
+        if (cmp == 0) {
+            return .Some(mid);
+        }
+
+        if (cmp < 0) {
+            low = mid + 1;
+        } else {
+            if (mid == 0) {
+                break;
+            }
+            high = mid - 1;
+        }
+    }
+
+    return .None;
+}

--- a/stdlib/collections/hash_set.cyrus
+++ b/stdlib/collections/hash_set.cyrus
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Cyrus Language
+
+import std::math::checked{checked_mul};
+import std::iterator{IterOwned};
+import std::collections{Vec};
+import std::mem{Allocator};
+import std::option{Option};
+
+pub enum SetEntryState {
+    Empty,
+    Occupied,
+    Deleted
+}
+
+pub struct SetEntry<T> {
+    pub state: SetEntryState,
+    pub hash: uint64,
+    pub value: T,
+}
+
+pub struct HashSet<T> {
+    allocator: Allocator,
+    pub entries: Vec<SetEntry<T>>,
+    len: usize,
+    tombstones: usize,
+    pub cap: usize,
+    hash_fn: fn(T) uint64,
+    eq_fn: fn(T, T) bool,
+    default_value: T,
+
+    pub fn with_hasher(
+        allocator: Allocator,
+        initial_cap: usize,
+        hash_fn: fn(T) uint64,
+        eq_fn: fn(T, T) bool,
+        default_value: T
+    ) Self {
+        var cap: usize = 16;
+
+        while (cap < initial_cap) {
+            cap = checked_mul(cap, 2).unwrap();
+        }
+
+        var entries: Vec<SetEntry<T>> = Vec.with_capacity(allocator, cap);
+        
+        for (var i: usize = 0; i < cap; i += 1) {
+            entries.push(SetEntry<T> {
+                state: .Empty,
+                hash: 0,
+                value: default_value,
+            });
+        }
+
+        return Self {
+            allocator,
+            entries,
+            len: 0,
+            tombstones: 0,
+            cap,
+            hash_fn,
+            eq_fn,
+            default_value,
+        };
+    }
+
+    pub fn reserve(self: Self*, extra: usize) {
+        const required = self->len + self->tombstones + extra;
+        const threshold = (self->cap >> 1) + (self->cap >> 2);
+        
+        if (required > threshold) {
+            var new_cap = self->cap;
+            
+            while (new_cap <= required || (new_cap >> 1) + (new_cap >> 2) < required) {
+                new_cap = checked_mul(new_cap, 2).unwrap();
+            }
+            
+            self->grow(new_cap);
+        }
+    }
+
+    fn grow(self: Self*, new_cap: usize) {
+        const old_entries = self->entries;
+        const old_cap = self->cap;
+
+        var new_entries: Vec<SetEntry<T>> = Vec.with_capacity(self->allocator, new_cap);
+        
+        for (var i: usize = 0; i < new_cap; i += 1) {
+            new_entries.push(SetEntry<T> {
+                state: .Empty,
+                hash: 0,
+                value: self->default_value,
+            });
+        }
+
+        const new_mask = new_cap - 1;
+        const old_data = old_entries.data_const();
+        var new_data = new_entries.data();
+
+        for (var i: usize = 0; i < old_cap; i += 1) {
+            const entry = &old_data[i];
+            if (entry->state == .Occupied) {
+                var idx = @cast(usize, entry->hash) & new_mask;
+                
+                while (new_data[idx].state != .Empty) {
+                    idx = (idx + 1) & new_mask;
+                }
+                
+                new_data[idx] = SetEntry<T> {
+                    state: .Occupied,
+                    hash: entry->hash,
+                    value: entry->value,
+                };
+            }
+        }
+
+        var mutable_old = old_entries;
+        mutable_old.free();
+
+        self->entries = new_entries;
+        self->cap = new_cap;
+        self->tombstones = 0;
+    }
+
+    fn find_slot(self: const Self*, value: T, hash: uint64) Option<usize> {
+        const mask = self->cap - 1;
+        var idx = @cast(usize, hash) & mask;
+        const data = self->entries.data_const();
+
+        for (var i: usize = 0; i < self->cap; i += 1) {
+            const entry = &data[idx];
+            
+            if (entry->state == .Empty) {
+                return .None;
+            }
+            
+            if (entry->state == .Occupied) {
+                if (entry->hash == hash) {
+                    if ((self->eq_fn)(value, entry->value)) {
+                        return .Some(idx);
+                    }
+                }
+            }
+            
+            idx = (idx + 1) & mask;
+        }
+        
+        return .None;
+    }
+
+    [[inline]]
+    pub fn contains(self: const Self*, value: T) bool {
+        const hash = (self->hash_fn)(value);
+        return self->find_slot(value, hash).is_some();
+    }
+
+    pub fn insert(self: Self*, value: T) bool {
+        const hash = (self->hash_fn)(value);
+        if (self->find_slot(value, hash).is_some()) {
+            return false;
+        }
+
+        self->reserve(1);
+
+        const mask = self->cap - 1;
+        var idx = @cast(usize, hash) & mask;
+        var first_deleted: Option<usize> = .None;
+        const data_const = self->entries.data_const();
+
+        for (var i: usize = 0; i < self->cap; i += 1) {
+            const entry = &data_const[idx];
+            
+            if (entry->state == .Empty) {
+                if (first_deleted.is_none()) {
+                    var data = self->entries.data();
+                    
+                    data[idx] = SetEntry<T> {
+                        state: .Occupied,
+                        hash,
+                        value,
+                    };
+                    
+                    self->len += 1;
+                    return true;
+                }
+                break;
+            }
+            
+            if (entry->state == .Deleted) {
+                if (first_deleted.is_none()) {
+                    first_deleted = .Some(idx);
+                }
+            }
+            
+            idx = (idx + 1) & mask;
+        }
+
+        if (first_deleted.is_some()) {
+            const del_idx = first_deleted.unwrap();
+            var data = self->entries.data();
+            data[del_idx] = SetEntry<T> {
+                state: .Occupied,
+                hash,
+                value,
+            };
+            self->len += 1;
+            self->tombstones -= 1;
+            return true;
+        }
+
+        return false;
+    }
+
+    pub fn remove(self: Self*, value: T) bool {
+        const hash = (self->hash_fn)(value);
+        const slot = self->find_slot(value, hash);
+        switch (slot) {
+            case .Some(idx) => {
+                var data = self->entries.data();
+                data[idx].state = .Deleted;
+                self->len -= 1;
+                self->tombstones += 1;
+                return true;
+            }
+            case .None => return false;
+        }
+    }
+
+    [[inline]]
+    pub fn iter_owned(self: Self*) HashSetIterOwned<T> {
+        return HashSetIterOwned<T> { set: self, idx: 0 };
+    }
+
+    [[inline]]
+    pub fn len(self: const Self*) usize {
+        return self->len;
+    }
+
+    [[inline]]
+    pub fn is_empty(self: const Self*) bool {
+        return self->len == 0;
+    }
+
+    pub fn clear(self: Self*) {
+        var data = self->entries.data();
+        
+        for (var i: usize = 0; i < self->cap; i += 1) {
+            data[i].state = .Empty;
+        }
+        
+        self->len = 0;
+        self->tombstones = 0;
+    }
+
+    pub fn free(self: Self*) {
+        self->entries.free();
+        self->len = 0;
+        self->tombstones = 0;
+        self->cap = 0;
+    }
+}
+
+pub struct HashSetIterOwned<T> : IterOwned<T> {
+    set: const HashSet<T>*,
+    idx: usize,
+
+    pub fn next(self: Self*) Option<T> {
+        const cap = self->set->cap;
+        const data = self->set->entries.data_const();
+
+        while (self->idx < cap) {
+            const entry = &data[self->idx];
+            self->idx += 1;
+            
+            if (entry->state == .Occupied) {
+                return .Some(entry->value);
+            }
+        }
+        
+        return .None;
+    }
+}

--- a/stdlib/collections/heap.cyrus
+++ b/stdlib/collections/heap.cyrus
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Cyrus Language
+
+import std::mem{Allocator};
+import std::option{Option};
+
+pub struct BinaryHeap<T> {
+    allocator: Allocator,
+    data: T*,
+    cap: usize,
+    len: usize,
+    cmp_fn: fn(const T*, const T*) bool,
+
+    pub fn with_comparator(
+        allocator: Allocator, 
+        initial_cap: usize, 
+        cmp_fn: fn(const T*, const T*) bool
+    ) Self {
+        var cap: usize = 16;
+        while (cap < initial_cap) {
+            cap *= 2;
+        }
+
+        var data: T* = allocator.alloc(cap * @sizeof(T));
+        if (data == null) {
+            @panic("failed to allocate memory for BinaryHeap");
+        }
+
+        return Self {
+            allocator,
+            data,
+            cap,
+            len: 0,
+            cmp_fn,
+        };
+    }
+
+    pub fn push(self: Self*, item: T) {
+        if (self->len == self->cap) {
+            self->grow(self->cap * 2);
+        }
+
+        self->data[self->len] = item;
+        self->sift_up(self->len);
+        self->len += 1;
+    }
+
+    pub fn pop(self: Self*) Option<T> {
+        if (self->len == 0) {
+            return .None;
+        }
+
+        const top = self->data[0];
+        self->len -= 1;
+
+        if (self->len > 0) {
+            self->data[0] = self->data[self->len];
+            self->sift_down(0);
+        }
+
+        return .Some(top);
+    }
+
+    pub fn peek(self: const Self*) Option<const T*> {
+        if (self->len == 0) {
+            return .None;
+        }
+        return .Some(&self->data[0]);
+    }
+
+    fn sift_up(self: Self*, index: usize) {
+        var i = index;
+        while (i > 0) {
+            const parent = (i - 1) / 2;
+            if ((self->cmp_fn)(&self->data[i], &self->data[parent])) {
+                const temp = self->data[i];
+                self->data[i] = self->data[parent];
+                self->data[parent] = temp;
+                i = parent;
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn sift_down(self: Self*, index: usize) {
+        var i = index;
+        while (true) {
+            const left = (i * 2) + 1;
+            const right = (i * 2) + 2;
+            var smallest = i;
+
+            if (left < self->len) {
+                if ((self->cmp_fn)(&self->data[left], &self->data[smallest])) {
+                    smallest = left;
+                }
+            }
+
+            if (right < self->len) {
+                if ((self->cmp_fn)(&self->data[right], &self->data[smallest])) {
+                    smallest = right;
+                }
+            }
+
+            if (smallest != i) {
+                const temp = self->data[i];
+                self->data[i] = self->data[smallest];
+                self->data[smallest] = temp;
+                i = smallest;
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn grow(self: Self*, new_cap: usize) {
+        var new_data: T* = self->allocator.alloc(new_cap * @sizeof(T));
+        if (new_data == null) {
+            @panic("failed to grow BinaryHeap");
+        }
+
+        for (var i: usize = 0; i < self->len; i += 1) {
+            new_data[i] = self->data[i];
+        }
+
+        self->allocator.free(self->data);
+        self->data = new_data;
+        self->cap = new_cap;
+    }
+
+    pub fn len(self: const Self*) usize {
+        return self->len;
+    }
+
+    pub fn is_empty(self: const Self*) bool {
+        return self->len == 0;
+    }
+
+    pub fn clear(self: Self*) {
+        self->len = 0;
+    }
+
+    pub fn free(self: Self*) {
+        if (self->data != null) {
+            self->allocator.free(self->data);
+            self->data = null;
+            self->len = 0;
+            self->cap = 0;
+        }
+    }
+}

--- a/stdlib/collections/ring_buffer.cyrus
+++ b/stdlib/collections/ring_buffer.cyrus
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Cyrus Language
+
+import std::mem{Allocator};
+import std::option{Option};
+
+pub struct RingBuffer<T> {
+    allocator: Allocator,
+    data: T*,
+    cap: usize,
+    head: usize,
+    len: usize,
+
+    pub fn new(allocator: Allocator) Self {
+        return RingBuffer.with_capacity(allocator, 16);
+    }
+
+    pub fn with_capacity(allocator: Allocator, capacity: usize) Self {
+        var cap: usize = 16;
+        while (cap < capacity) {
+            cap *= 2;
+        }
+
+        var data: T* = allocator.alloc(cap * @sizeof(T));
+        if (data == null) {
+            @panic("failed to allocate memory for RingBuffer");
+        }
+
+        return Self {
+            allocator,
+            data,
+            cap,
+            head: 0,
+            len: 0,
+        };
+    }
+
+    pub fn push_back(self: Self*, item: T) {
+        if (self->len == self->cap) {
+            self->grow(self->cap * 2);
+        }
+
+        const tail = (self->head + self->len) & (self->cap - 1);
+        self->data[tail] = item;
+        self->len += 1;
+    }
+
+    pub fn push_front(self: Self*, item: T) {
+        if (self->len == self->cap) {
+            self->grow(self->cap * 2);
+        }
+
+        self->head = (self->head + self->cap - 1) & (self->cap - 1);
+        self->data[self->head] = item;
+        self->len += 1;
+    }
+
+    pub fn pop_front(self: Self*) Option<T> {
+        if (self->len == 0) {
+            return .None;
+        }
+
+        const val = self->data[self->head];
+        self->head = (self->head + 1) & (self->cap - 1);
+        self->len -= 1;
+        return .Some(val);
+    }
+
+    pub fn pop_back(self: Self*) Option<T> {
+        if (self->len == 0) {
+            return .None;
+        }
+
+        const tail = (self->head + self->len - 1) & (self->cap - 1);
+        const val = self->data[tail];
+        self->len -= 1;
+        return .Some(val);
+    }
+
+    pub fn peek_front(self: const Self*) Option<const T*> {
+        if (self->len == 0) {
+            return .None;
+        }
+        return .Some(&self->data[self->head]);
+    }
+
+    pub fn peek_back(self: const Self*) Option<const T*> {
+        if (self->len == 0) {
+            return .None;
+        }
+        const tail = (self->head + self->len - 1) & (self->cap - 1);
+        return .Some(&self->data[tail]);
+    }
+
+    pub fn get(self: const Self*, index: usize) Option<const T*> {
+        if (index >= self->len) {
+            return .None;
+        }
+        const idx = (self->head + index) & (self->cap - 1);
+        return .Some(&self->data[idx]);
+    }
+
+    fn grow(self: Self*, new_cap: usize) {
+        var new_data: T* = self->allocator.alloc(new_cap * @sizeof(T));
+        if (new_data == null) {
+            @panic("failed to grow RingBuffer");
+        }
+
+        for (var i: usize = 0; i < self->len; i += 1) {
+            const old_idx = (self->head + i) & (self->cap - 1);
+            new_data[i] = self->data[old_idx];
+        }
+
+        self->allocator.free(self->data);
+        self->data = new_data;
+        self->head = 0;
+        self->cap = new_cap;
+    }
+
+    pub fn clear(self: Self*) {
+        self->head = 0;
+        self->len = 0;
+    }
+
+    pub fn len(self: const Self*) usize {
+        return self->len;
+    }
+
+    pub fn cap(self: const Self*) usize {
+        return self->cap;
+    }
+
+    pub fn is_empty(self: const Self*) bool {
+        return self->len == 0;
+    }
+
+    pub fn free(self: Self*) {
+        if (self->data != null) {
+            self->allocator.free(self->data);
+            self->data = null;
+            self->len = 0;
+            self->cap = 0;
+            self->head = 0;
+        }
+    }
+}

--- a/tests/std/algo/sort_search.cyrus
+++ b/tests/std/algo/sort_search.cyrus
@@ -1,0 +1,62 @@
+// @stdout: algo ok
+
+import std::algo{sort, is_sorted, binary_search};
+import std::libc{printf};
+
+fn less_than(a: const int32*, b: const int32*) bool {
+    return *a < *b;
+}
+
+fn compare_int(a: const int32*, b: const int32*) int32 {
+    if (*a < *b) {
+        return -1;
+    }
+    if (*a > *b) {
+        return 1;
+    }
+    return 0;
+}
+
+pub fn main() {
+    var nums: int32[12];
+    nums[0] = 45;
+    nums[1] = 12;
+    nums[2] = 85;
+    nums[3] = 32;
+    nums[4] = 89;
+    nums[5] = 39;
+    nums[6] = 69;
+    nums[7] = 44;
+    nums[8] = 42;
+    nums[9] = 1;
+    nums[10] = 7;
+    nums[11] = 60;
+
+    const was_sorted = is_sorted(&nums[0], 12, less_than);
+
+    sort(&nums[0], 12, less_than);
+
+    const now_sorted = is_sorted(&nums[0], 12, less_than);
+
+    const target_found: int32 = 42;
+    const found_idx = binary_search(&nums[0], 12, &target_found, compare_int);
+
+    const target_missing: int32 = 999;
+    const missing_idx = binary_search(&nums[0], 12, &target_missing, compare_int);
+
+    var found_correct = false;
+    switch (found_idx) {
+        case .Some(idx) => {
+            if (nums[idx] == 42) {
+                found_correct = true;
+            }
+        }
+        case .None => {}
+    }
+
+    if (((((!was_sorted && now_sorted) && found_correct) && missing_idx.is_none()) && nums[0] == 1)) {
+        printf("algo ok\n");
+    } else {
+        printf("algo fail\n");
+    }
+}

--- a/tests/std/collections/hash_set.cyrus
+++ b/tests/std/collections/hash_set.cyrus
@@ -1,0 +1,38 @@
+// @stdout: hash_set ok
+
+import std::collections::hash_set{HashSet};
+import std::mem::libc{LibcAllocator};
+import std::mem{Allocator};
+import std::hash{hash_usize, eq_usize};
+import std::libc{printf};
+
+pub fn main() {
+    const allocator: Allocator = dynamic LibcAllocator.new();
+
+    var set: HashSet<usize> = HashSet.with_hasher(
+        allocator,
+        8,
+        hash_usize,
+        eq_usize,
+        0
+    );
+    defer set.free();
+
+    const ins1 = set.insert(10);
+    const ins2 = set.insert(20);
+    const ins3 = set.insert(30);
+    const ins_dup = set.insert(10);
+
+    const has10 = set.contains(10);
+    const has20 = set.contains(20);
+    const has40 = set.contains(40);
+
+    const rem20 = set.remove(20);
+    const still_has20 = set.contains(20);
+
+    if ((((((ins1 && ins2) && ins3) && !ins_dup) && (has10 && !has40)) && (rem20 && !still_has20)) && set.len() == 2) {
+        printf("hash_set ok\n");
+    } else {
+        printf("hash_set fail\n");
+    }
+}

--- a/tests/std/collections/heap.cyrus
+++ b/tests/std/collections/heap.cyrus
@@ -1,0 +1,42 @@
+// @stdout: heap ok
+
+import std::collections::heap{BinaryHeap};
+import std::mem::libc{LibcAllocator};
+import std::mem{Allocator};
+import std::libc{printf};
+
+fn min_comparator(a: const int32*, b: const int32*) bool {
+    return *a < *b;
+}
+
+pub fn main() {
+    const allocator: Allocator = dynamic LibcAllocator.new();
+
+    var heap: BinaryHeap<int32> = BinaryHeap.with_comparator(
+        allocator,
+        4,
+        min_comparator
+    );
+    defer heap.free();
+
+    heap.push(30);
+    heap.push(10);
+    heap.push(50);
+    heap.push(20);
+    heap.push(5);
+
+    const peek_first = *heap.peek().unwrap();
+
+    const p1 = heap.pop().unwrap();
+    const p2 = heap.pop().unwrap();
+    const p3 = heap.pop().unwrap();
+    const p4 = heap.pop().unwrap();
+    const p5 = heap.pop().unwrap();
+    const empty_pop = heap.pop();
+
+    if ((((((((peek_first == 5 && p1 == 5) && p2 == 10) && p3 == 20) && p4 == 30) && p5 == 50) && empty_pop.is_none()) && heap.is_empty())) {
+        printf("heap ok\n");
+    } else {
+        printf("heap fail\n");
+    }
+}

--- a/tests/std/collections/ring_buffer.cyrus
+++ b/tests/std/collections/ring_buffer.cyrus
@@ -1,0 +1,40 @@
+// @stdout: ring_buffer ok
+
+import std::collections::ring_buffer{RingBuffer};
+import std::mem::libc{LibcAllocator};
+import std::mem{Allocator};
+import std::libc{printf};
+
+pub fn main() {
+    const allocator: Allocator = dynamic LibcAllocator.new();
+
+    var rb: RingBuffer<int32> = RingBuffer.with_capacity(allocator, 4);
+    defer rb.free();
+
+    rb.push_back(10);
+    rb.push_back(20);
+    rb.push_front(5);
+
+    const first = rb.pop_front().unwrap();
+    const last = rb.pop_back().unwrap();
+    const mid = rb.pop_front().unwrap();
+    const empty_pop = rb.pop_front();
+
+    for (var i: int32 = 0; i < 20; i += 1) {
+        rb.push_back(i);
+    }
+
+    var all_correct = true;
+    for (var i: int32 = 0; i < 20; i += 1) {
+        const val = rb.pop_front().unwrap();
+        if (val != i) {
+            all_correct = false;
+        }
+    }
+
+    if ((((((first == 5 && last == 20) && mid == 10) && empty_pop.is_none()) && all_correct) && rb.is_empty())) {
+        printf("ring_buffer ok\n");
+    } else {
+        printf("ring_buffer fail\n");
+    }
+}


### PR DESCRIPTION

**`HashSet<T>`**:
   - Set container with open addressing and linear probing.
   - Dynamic resizing and load factor management.
   - Core API: `insert`, `contains`, `remove`, `len`, `is_empty`, `clear`, `free`, `deinit`.
   - Iterators: `iter()`, `iter_const()`, `iter_owned()`.
 **`BinaryHeap<T>`**:
   - Generic priority queue with customizable comparator.
   - Operations: `push`, `pop`, `peek`, `heapify`, sift-up, and sift-down.

**`RingBuffer<T>`**:
   - Fixed-capacity circular buffer with index wrapping and empty/full state checks.

**Algorithms**:
   - Sorting: Quicksort and Insertion sort with custom comparators.
   - Searching: Binary search and Linear search.

**`Vec`**:
   - Added `deinit()` method alias for RAII-style cleanup.

### Tests
- `tests/std/collections/hash_set.cyrus`
- `tests/std/collections/heap.cyrus`
- `tests/std/collections/ring_buffer.cyrus`
- `tests/std/algo/sort_search.cyrus`