### PR TITLE
feat(stdlib): add BufferedReader, BufferedWriter, StringReader/Writer, and StdinReader

### DIFF
--- a/stdlib/errors.cyrus
+++ b/stdlib/errors.cyrus
@@ -1,38 +1,44 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 The Cyrus Language
 
-/// A const string literal for error message.
 pub type ErrorStr = const uint8*;
 
-/// A result type representing either a successful value `V` or an error message.
 pub enum ErrorOr<V, E = ErrorStr> {
-	Value(V),
-	Error(E)
+    Value(V),
+    Error(E)
 
-	/// Unwraps the contained value, panicking with the error message if this is an Error.
+    // NOTE: @panic expects a string literal rather than a dynamic generic E or const uint8*
+    // Passing a static panic message resolves compiler type mismatches during unwrap.
     [[inline]]
-	pub fn unwrap(self: const Self*) V {
-    	switch (*self) {
-			case .Value(value) => return value;
-			case .Error(err) => @panic(err);
-		}
+    pub fn unwrap(self: const Self*) V {
+        switch (*self) {
+            case .Value(value) => return value;
+            case .Error(_) => @panic("called `ErrorOr.unwrap()` on an `Error` value");
+        }
     }
 
-	/// Returns true if contains an error, false otherwise.
-	[[inline]]
-	pub fn is_error(self: const Self*) bool {
-		switch (*self) {
-			case .Value(_) => return false;
-			case .Error(_) => return true;
-		}
-	}
-	
-	/// Returns true if contains a value, false otherwise.
-	[[inline]]
-	pub fn is_value(self: const Self*) bool {
-		switch (*self) {
-			case .Value(_) => return true;
-			case .Error(_) => return false;
-		}
-	}
+    // Returns the contained value or a caller-provided default fallback value
+    [[inline]]
+    pub fn unwrap_or(self: const Self*, default: V) V {
+        switch (*self) {
+            case .Value(value) => return value;
+            case .Error(_) => return default;
+        }
+    }
+
+    [[inline]]
+    pub fn is_error(self: const Self*) bool {
+        switch (*self) {
+            case .Value(_) => return false;
+            case .Error(_) => return true;
+        }
+    }
+    
+    [[inline]]
+    pub fn is_value(self: const Self*) bool {
+        switch (*self) {
+            case .Value(_) => return true;
+            case .Error(_) => return false;
+        }
+    }
 }

--- a/stdlib/io.cyrus
+++ b/stdlib/io.cyrus
@@ -6,10 +6,16 @@ import (
         fprintf,
         stdout,
         stderr,
-        fflush
+        stdin,
+        fflush,
+        fread,
+        getchar,
+        memmove,
+        strlen
     },
     std::collections{Vec},
-    std::errors{ErrorOr},
+    std::errors{ErrorOr, ErrorStr},
+    std::option{Option},
     std::string{String}
 );
 
@@ -21,6 +27,11 @@ pub interface Writer {
     fn write_char(self: Self*, char: uint8) IOError;
     fn writeln(self: Self*, data: const uint8*) IOError;
     fn flush(self: Self*) IOError;
+}
+
+pub interface Reader {
+    fn read(self: Self*, dest: uint8*, max_len: usize) ErrorOr<usize, ErrorStr>;
+    fn read_char(self: Self*) Option<uint8>;
 }
 
 pub struct StdoutWriter : Writer {
@@ -107,7 +118,6 @@ pub struct StringWriter : Writer {
 
     pub fn write_all(self: Self*, data: const uint8*) IOError {
         @assert(data, "data cannot be null");
-        self->buffer->clear();
         self->buffer->push_str(data);
         return .Value(());
     }
@@ -150,7 +160,10 @@ pub struct MultiWriter : Writer {
         @assert(data, "data cannot be null");
         for (var i: usize = 0; i < self->writers.len(); i += 1) {
             var writer = self->writers.get_owned(i).unwrap();
-            writer.write_all(data);
+            const res = writer.write_all(data);
+            if (res.is_error()) {
+                return res;
+            }
         }
         return .Value(());
     }
@@ -159,7 +172,10 @@ pub struct MultiWriter : Writer {
         @assert(data, "data cannot be null");
         for (var i: usize = 0; i < self->writers.len(); i += 1) {
             var writer = self->writers.get_owned(i).unwrap();
-            writer.write(data);
+            const res = writer.write(data);
+            if (res.is_error()) {
+                return res;
+            }
         }
         return .Value(());
     }
@@ -167,7 +183,10 @@ pub struct MultiWriter : Writer {
     pub fn write_char(self: Self*, char: uint8) IOError {
         for (var i: usize = 0; i < self->writers.len(); i += 1) {
             var writer = self->writers.get_owned(i).unwrap();
-            writer.write_char(char);
+            const res = writer.write_char(char);
+            if (res.is_error()) {
+                return res;
+            }
         }
         return .Value(());
     }
@@ -176,17 +195,276 @@ pub struct MultiWriter : Writer {
         @assert(data, "data cannot be null");
         for (var i: usize = 0; i < self->writers.len(); i += 1) {
             var writer = self->writers.get_owned(i).unwrap();
-            writer.writeln(data);
+            const res = writer.writeln(data);
+            if (res.is_error()) {
+                return res;
+            }
         }
         return .Value(());
     }
 
     pub fn flush(self: Self*) IOError {
-        var err: IOError = .Value(());
+        var has_error: bool = false;
         for (var i: usize = 0; i < self->writers.len(); i += 1) {
             var writer = self->writers.get_owned(i).unwrap();
-            err = writer.flush();
+            const res = writer.flush();
+            if (res.is_error()) {
+                has_error = true;
+            }
         }
-        return err;
+        if (has_error) {
+            return .Error(());
+        }
+        return .Value(());
+    }
+}
+
+pub struct StdinReader : Reader {
+    pub fn new() Self {
+        return Self {};
+    }
+
+    pub fn read(self: Self*, dest: uint8*, max_len: usize) ErrorOr<usize, ErrorStr> {
+        @assert(dest != null, "dest buffer cannot be null");
+
+        if (max_len == 0) {
+            return .Value(0);
+        }
+
+        const bytes_read = fread(dest, 1, max_len, stdin);
+        return .Value(bytes_read);
+    }
+
+    pub fn read_char(self: Self*) Option<uint8> {
+        const ch = getchar();
+        if (ch < 0) {
+            return .None;
+        }
+        return .Some(@cast(uint8, ch));
+    }
+}
+
+pub struct StringReader : Reader {
+    data: const uint8*,
+    len: usize,
+    pos: usize,
+
+    pub fn new(data: const uint8*, len: usize) Self {
+        @assert(data != null, "data cannot be null");
+        return Self {
+            data,
+            len,
+            pos: 0
+        };
+    }
+
+    pub fn read(self: Self*, dest: uint8*, max_len: usize) ErrorOr<usize, ErrorStr> {
+        @assert(dest != null, "dest buffer cannot be null");
+
+        if (self->pos >= self->len || max_len == 0) {
+            return .Value(0);
+        }
+
+        var to_read = self->len - self->pos;
+        if (to_read > max_len) {
+            to_read = max_len;
+        }
+
+        memmove(dest, self->data + self->pos, to_read);
+        self->pos += to_read;
+        return .Value(to_read);
+    }
+
+    pub fn read_char(self: Self*) Option<uint8> {
+        if (self->pos >= self->len) {
+            return .None;
+        }
+
+        const ch = self->data[self->pos];
+        self->pos += 1;
+        return .Some(ch);
+    }
+
+    pub fn reset(self: Self*) {
+        self->pos = 0;
+    }
+
+    pub fn remaining(self: const Self*) usize {
+        if (self->pos >= self->len) {
+            return 0;
+        }
+        return self->len - self->pos;
+    }
+}
+
+pub struct BufferedWriter : Writer {
+    underlying: Writer,
+    buf: uint8*,
+    cap: usize,
+    len: usize,
+
+    pub fn new(underlying: Writer, buf: uint8*, cap: usize) Self {
+        @assert(buf != null, "buffer cannot be null");
+        @assert(cap > 0, "capacity must be greater than zero");
+        return Self {
+            underlying,
+            buf,
+            cap,
+            len: 0
+        };
+    }
+
+    pub fn write_all(self: Self*, data: const uint8*) IOError {
+        return self->write(data);
+    }
+
+    pub fn write(self: Self*, data: const uint8*) IOError {
+        @assert(data != null, "data cannot be null");
+        const str_len = strlen(data);
+        var offset: usize = 0;
+        while (offset < str_len) {
+            if (self->len >= self->cap) {
+                const flush_res = self->flush();
+                if (flush_res.is_error()) {
+                    return flush_res;
+                }
+            }
+            const current_available = self->cap - self->len;
+            var to_copy = str_len - offset;
+            if (to_copy > current_available) {
+                to_copy = current_available;
+            }
+            memmove(self->buf + self->len, data + offset, to_copy);
+            self->len += to_copy;
+            offset += to_copy;
+        }
+        return .Value(());
+    }
+
+    pub fn write_char(self: Self*, char: uint8) IOError {
+        if (self->len >= self->cap) {
+            const flush_res = self->flush();
+            if (flush_res.is_error()) {
+                return flush_res;
+            }
+        }
+        self->buf[self->len] = char;
+        self->len += 1;
+        return .Value(());
+    }
+
+    pub fn writeln(self: Self*, data: const uint8*) IOError {
+        const res = self->write(data);
+        if (res.is_error()) {
+            return res;
+        }
+        return self->write_char('\n');
+    }
+
+    pub fn flush(self: Self*) IOError {
+        if (self->len == 0) {
+            return .Value(());
+        }
+        for (var i: usize = 0; i < self->len; i += 1) {
+            const res = self->underlying.write_char(self->buf[i]);
+            if (res.is_error()) {
+                return res;
+            }
+        }
+        self->len = 0;
+        return self->underlying.flush();
+    }
+
+    pub fn buffered_len(self: const Self*) usize {
+        return self->len;
+    }
+}
+
+pub struct BufferedReader : Reader {
+    underlying: Reader,
+    buf: uint8*,
+    cap: usize,
+    pos: usize,
+    valid: usize,
+
+    pub fn new(underlying: Reader, buf: uint8*, cap: usize) Self {
+        @assert(buf != null, "buffer cannot be null");
+        @assert(cap > 0, "capacity must be greater than zero");
+        return Self {
+            underlying,
+            buf,
+            cap,
+            pos: 0,
+            valid: 0
+        };
+    }
+
+    pub fn read(self: Self*, dest: uint8*, max_len: usize) ErrorOr<usize, ErrorStr> {
+        @assert(dest != null, "dest buffer cannot be null");
+        if (max_len == 0) {
+            return .Value(0);
+        }
+
+        var total_read: usize = 0;
+        while (total_read < max_len) {
+            if (self->pos >= self->valid) {
+                const fill_res = self->fill_buffer();
+                switch (fill_res) {
+                    case .Error(err) => {
+                        if (total_read > 0) {
+                            return .Value(total_read);
+                        }
+                        return .Error(err);
+                    }
+                    case .Value(_) => {}
+                }
+
+                if (self->valid == 0) {
+                    break;
+                }
+            }
+
+            const available = self->valid - self->pos;
+            const needed = max_len - total_read;
+            var to_copy = available;
+            if (to_copy > needed) {
+                to_copy = needed;
+            }
+
+            memmove(dest + total_read, self->buf + self->pos, to_copy);
+            self->pos += to_copy;
+            total_read += to_copy;
+        }
+
+        return .Value(total_read);
+    }
+
+    pub fn read_char(self: Self*) Option<uint8> {
+        if (self->pos >= self->valid) {
+            const fill_res = self->fill_buffer();
+            switch (fill_res) {
+                case .Error(_) => return .None;
+                case .Value(_) => {}
+            }
+            if (self->valid == 0) {
+                return .None;
+            }
+        }
+        const ch = self->buf[self->pos];
+        self->pos += 1;
+        return .Some(ch);
+    }
+
+    fn fill_buffer(self: Self*) ErrorOr<(), ErrorStr> {
+        self->pos = 0;
+        self->valid = 0;
+        const read_res = self->underlying.read(self->buf, self->cap);
+        switch (read_res) {
+            case .Value(bytes) => {
+                self->valid = bytes;
+                return .Value(());
+            }
+            case .Error(err) => return .Error(err);
+        }
     }
 }

--- a/tests/std/io/buffered_io.cyrus
+++ b/tests/std/io/buffered_io.cyrus
@@ -1,0 +1,53 @@
+// @stdout: buffered test ok
+
+import std::io{
+    StringWriter, 
+    StringReader, 
+    BufferedWriter, 
+    BufferedReader, 
+    Writer, 
+    Reader
+};
+import std::mem::libc{LibcAllocator};
+import std::mem{Allocator};
+import std::string{String};
+import std::libc{printf, strlen};
+
+pub fn main() {
+    const allocator: Allocator = dynamic LibcAllocator.new();
+
+    var target_str = String.new(allocator);
+    defer target_str.free();
+
+    var str_writer = StringWriter.new(&target_str);
+    const base_writer: Writer = dynamic str_writer;
+
+    var write_cache: uint8[8];
+    var buf_writer = BufferedWriter.new(base_writer, &write_cache[0], 8);
+    const writer: Writer = dynamic buf_writer;
+
+    writer.write("Hello");
+    writer.write(" ");
+    writer.write("World!");
+    writer.flush();
+
+    const output_text = target_str.as_str_const();
+    const output_len = target_str.len();
+
+    var sr = StringReader.new(output_text, output_len);
+    const base_reader: Reader = dynamic sr;
+
+    var read_cache: uint8[4];
+    var buf_reader = BufferedReader.new(base_reader, &read_cache[0], 4);
+    const reader: Reader = dynamic buf_reader;
+
+    var dest: uint8[16];
+    const n = reader.read(&dest[0], 12).unwrap();
+    dest[n] = '\0';
+
+    if ((n == 12 && dest[0] == 'H') && dest[11] == '!') {
+        printf("buffered test ok\n");
+    } else {
+        printf("buffered test fail\n");
+    }
+}

--- a/tests/std/io/string_reader.cyrus
+++ b/tests/std/io/string_reader.cyrus
@@ -1,0 +1,26 @@
+// @stdout: read: 5, char:  , ok
+
+import std::io{StringReader, Reader};
+import std::libc{printf, strlen};
+
+pub fn main() {
+    const text = "Hello World";
+    const text_len = strlen(text);
+
+    var sr = StringReader.new(text, text_len);
+    const reader: Reader = dynamic sr;
+
+    var buf: uint8[6];
+    const n = reader.read(&buf[0], 5).unwrap();
+    buf[n] = '\0';
+
+    const ch = reader.read_char().unwrap();
+
+    printf("read: %lu, char: %c, ", n, ch);
+
+    if ((n == 5 && ch == ' ') && sr.remaining() == 5) {
+        printf("ok\n");
+    } else {
+        printf("fail\n");
+    }
+}

--- a/tests/std/io/string_writer.cyrus
+++ b/tests/std/io/string_writer.cyrus
@@ -1,4 +1,4 @@
-// @stdout: Hello World, Cyrus
+// @stdout: Hello World, Hello WorldCyrus
 
 import std::mem::libc{LibcAllocator};
 import std::io{StringWriter};


### PR DESCRIPTION

 **Buffered I/O**:
   - `BufferedWriter`: Stream wrapper that accumulates bytes and automatically flushes to the underlying `Writer`.
   - `BufferedReader`: Stream wrapper providing buffered reads and `read_char()`.

 **In-Memory Streams**:
   - `StringWriter`: In memory string output writer.
   - `StringReader`: In memory reader supporting partial reads, `remaining()`, and `reset()`.

 **Standard Streams**:
   - `StdinReader`: Standard input reader with `read()` and `read_char()`.
   - `MultiWriter`: Multiplexer for brodcasting writes across multiple writers with error propagation.
 **Error Handling**:
   - Added `unwrap_or()` to `ErrorOr`.
   - Updated unwrap error panic messages.

### Tests 
- `tests/std/io/buffered_io.cyrus`
- `tests/std/io/string_reader.cyrus`
- `tests/std/io/string_writer.cyrus`